### PR TITLE
remove instructure logo from dashboard

### DIFF
--- a/app/views/shared/_canvas_footer.erb
+++ b/app/views/shared/_canvas_footer.erb
@@ -17,14 +17,9 @@
 %>
 
 <footer role="contentinfo" id="footer" class="ic-app-footer">
-  <a href="http://www.instructure.com" class="footer-logo ic-app-footer__logo-link">
-    <span class="screenreader-only">
-      <%= t(:by_instructure, 'By Instructure') %>
-    </span>
-  </a>
   <div id="footer-links" class="ic-app-footer__links">
     <% if Setting.get("show_opensource_linkback", "false") == "true" %>
-      <a href="http://instructure.com"><%= t('open_source_learning_management_system', 'Open Source LMS') %></a>
+      <a href="https://github.com/StrongMind/canvas-lms"><%= t('open_source_learning_management_system', 'Modified Open Source LMS') %></a>
     <% end %>
     <%= render :partial => 'shared/footer_links' %>
   </div>


### PR DESCRIPTION
Removed logo and renamed to "Modified Open Source" per previous discussions.

[VIEW LICENSE](https://github.com/instructure/canvas-lms/blob/stable/LICENSE#L196)

>>> New and old look
<img width="1152" alt="user_dashboard_and_developer_tools_-_http___localhost_3000__and_canvas-lms_redis_yml_example_at_stable_ _instructure_canvas-lms" src="https://user-images.githubusercontent.com/1052259/31559012-fa052bd8-b003-11e7-998c-f61e6e324bb8.png">
<img width="957" alt="user_dashboard" src="https://user-images.githubusercontent.com/1052259/31559042-199c2b90-b004-11e7-9089-125acbab94df.png">

