### PR TITLE
Update run_test_suite.sh to fix db errors

### DIFF
--- a/script/run_test_suite.sh
+++ b/script/run_test_suite.sh
@@ -23,7 +23,7 @@ TS=$(date +%FT%T)
 docker-compose build
 docker-compose run --rm web bundle install
 docker-compose run --rm web bundle exec rake db:create db:initial_setup canvas:compile_assets_dev
-docker-compose run --rm web bundle exec rake db:create
-docker-compose run --rm web bundle exec rake db:migrate
+docker-compose run --rm web bundle exec rake db:create RAILS_ENV=test
+docker-compose run --rm web bundle exec rake db:migrate RAILS_ENV=test
 docker-compose up -d
 docker-compose run -d web bundle exec rspec spec --format documentation  --out test_results/rspec-$TS.md


### PR DESCRIPTION
```
# /home/docker/.gem/ruby/2.4.0/gems/activesupport-5.0.4/lib/active_support/dependencies.rb:287:in `load'
# ------------------
# --- Caused by: ---
# PG::UndefinedTable:
#   ERROR:  relation "accounts" does not exist
#   LINE 8:                WHERE a.attrelid = '"accounts"'::regclass
#                                             ^
#   /home/docker/.gem/ruby/2.4.0/gems/activerecord-5.0.4/lib/active_record/connection_adapters/postgresql/database_statements.rb:88:in `async_exec'
Finished in 0.00152 seconds (files took 2 minutes 24.5 seconds to load)
0 examples, 0 failures, 1576 errors occurred outside of examples
root@ip-172-31-33-135:~/test_results# cd ..
root@ip-172-31-33-135:~# # /home/docker/.gem/ruby/2.4.0/gems/activesupport-5.0.4/lib/active_support/dependencies.rb:287:in `load'
root@ip-172-31-33-135:~# # ------------------
root@ip-172-31-33-135:~# # --- Caused by: ---
root@ip-172-31-33-135:~# # PG::UndefinedTable:
root@ip-172-31-33-135:~# #   ERROR:  relation "accounts" does not exist
root@ip-172-31-33-135:~# #   LINE 8:                WHERE a.attrelid = '"accounts"'::regclass
root@ip-172-31-33-135:~# #                                             ^
root@ip-172-31-33-135:~# #   /home/docker/.gem/ruby/2.4.0/gems/activerecord-5.0.4/lib/active_record/connection_adapters/postgresql/database_statements.rb:88:in `async_exec'
root@ip-172-31-33-135:~# Finished in 0.00152 seconds (files took 2 minutes 24.5 seconds to load)
-su: syntax error near unexpected token `('
root@ip-172-31-33-135:~# 0 examples, 0 failures, 1576 errors occurred outside of examples
```