### PR TITLE
CSS now targets speed grader specifically, rather than both grades pages

### DIFF
--- a/app/stylesheets/base/_layout.scss
+++ b/app/stylesheets/base/_layout.scss
@@ -76,7 +76,7 @@ body {
     }
   }
 
-  &.full-width.grades { // Speedgrader
+  &.full-width.grades:not(.gradebook) { // Speedgrader
 
     .ic-Layout-wrapper {
         max-width: unset !important;


### PR DESCRIPTION
body.full-width.grades <=== targets BOTH gradebook and speedgrader

body.full-width.grades:not(.gradebook) <=== targets ONLY speedgrader, so that speedgrader ignores the left side bar.