### PR TITLE
Play 1007 add permission for delete inbox

### DIFF
--- a/app/coffeescripts/models/Message.coffee
+++ b/app/coffeescripts/models/Message.coffee
@@ -70,6 +70,7 @@ define [
           message.context_name = data.context_name
           message.has_attachments = message.media_comment || message.attachments.length
           message.bodyHTML = TextHelper.formatMessage(message.body)
+          message.can_delete = ENV.CONVERSATIONS.CAN_DELETE_INBOX_MESSAGES
       data
 
     handleMessages: ->

--- a/app/coffeescripts/views/conversations/MessageDetailView.coffee
+++ b/app/coffeescripts/views/conversations/MessageDetailView.coffee
@@ -51,7 +51,8 @@ define [
         context   = @model.toJSON().conversation
         context.starToggleMessage = if @model.starred() then @messages['unstar'] else @messages['star']
         context.archiveToggleMessage = if @model.get('workflow_state') == 'archived' then @messages['unarchive'] else @messages['archive']
-        $template = $(template(context))
+        context.can_delete = ENV.CONVERSATIONS.CAN_DELETE_INBOX_MESSAGES
+        $template = $(template(context)) 
         @model.messageCollection.each (message) =>
           message.set('conversation_id', context.id) unless message.get('conversation_id')
           message.set('cannot_reply', context.cannot_reply) if context.cannot_reply

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -285,15 +285,19 @@ class ConversationsController < ApplicationController
         :ACCOUNT_CONTEXT_CODE => "account_#{@domain_root_account.id}",
         :CAN_MESSAGE_ACCOUNT_CONTEXT => valid_account_context?(@domain_root_account),
         :MAX_GROUP_CONVERSATION_SIZE => Conversation.max_group_conversation_size,
-        :CAN_DELETE_INBOX_MESSAGES => can_do(Account.first, @current_user, :delete_inbox_messages)
-      }
+      } 
+      
+     
+      is_admin = @current_user.roles(Account.site_admin).include? 'admin'
+        
+      hash[:CAN_DELETE_INBOX_MESSAGES] = is_admin || @current_user.enrollments.active.any? { |e| e.has_permission_to?(:delete_inbox_messages) }
 
       notes_enabled_accounts = @current_user.associated_accounts.where(enable_user_notes: true)
 
       hash[:NOTES_ENABLED] = notes_enabled_accounts.any?
       hash[:CAN_ADD_NOTES_FOR_ACCOUNT] = notes_enabled_accounts.any? {|a| a.grants_right?(@current_user, :manage_students) }
 
-      if hash[:NOTES_ENABLED] && !hash[:CAN_ADD_NOTES_FOR_ACCOUNT]
+      if hash[:NOTES_ENABLED] && !hash[:CAN_ADD_NOTES_FOR_ACCOUNT] 
         course_note_permissions = {}
         @current_user.enrollments.active.of_instructor_type.preload(:course).each do |enrollment|
           course_note_permissions[enrollment.course_id] = true if enrollment.has_permission_to?(:manage_user_notes)

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -284,7 +284,8 @@ class ConversationsController < ApplicationController
         :ATTACHMENTS_FOLDER_ID => @current_user.conversation_attachments_folder.id.to_s,
         :ACCOUNT_CONTEXT_CODE => "account_#{@domain_root_account.id}",
         :CAN_MESSAGE_ACCOUNT_CONTEXT => valid_account_context?(@domain_root_account),
-        :MAX_GROUP_CONVERSATION_SIZE => Conversation.max_group_conversation_size
+        :MAX_GROUP_CONVERSATION_SIZE => Conversation.max_group_conversation_size,
+        :CAN_DELETE_INBOX_MESSAGES => can_do(Account.first, @current_user, :delete_inbox_messages)
       }
 
       notes_enabled_accounts = @current_user.associated_accounts.where(enable_user_notes: true)

--- a/app/models/role_override.rb
+++ b/app/models/role_override.rb
@@ -128,6 +128,8 @@ class RoleOverride < ActiveRecord::Base
         :restrict_future_enrollments => true,
         :applies_to_concluded => ['TeacherEnrollment', 'TaEnrollment']
       },
+
+      # StrongMind added
       :delete_inbox_messages => {
         :label => lambda { "Delete inbox messages" },
         :available_to => [

--- a/app/models/role_override.rb
+++ b/app/models/role_override.rb
@@ -128,6 +128,29 @@ class RoleOverride < ActiveRecord::Base
         :restrict_future_enrollments => true,
         :applies_to_concluded => ['TeacherEnrollment', 'TaEnrollment']
       },
+      :delete_inbox_messages => {
+        :label => lambda { "Delete inbox messages" },
+        :available_to => [
+          'StudentEnrollment',
+          'TaEnrollment',
+          'TeacherEnrollment',
+          'DesignerEnrollment',
+          'TeacherlessStudentEnrollment',
+          'ObserverEnrollment',
+          'AccountAdmin',
+          'AccountMembership'
+        ],
+        :true_for => [
+          'StudentEnrollment',
+          'TaEnrollment',
+          'TeacherEnrollment',
+          'DesignerEnrollment',
+          'TeacherlessStudentEnrollment',
+          'ObserverEnrollment',
+          'AccountAdmin',
+          'AccountMembership'
+        ]
+      },
       :moderate_forum => {
         :label => lambda { t('permissions.moderate_form', "Moderate discussions ( delete / edit other's posts, lock topics)") },
         :available_to => [

--- a/app/views/jst/conversations/messageDetail.handlebars
+++ b/app/views/jst/conversations/messageDetail.handlebars
@@ -51,10 +51,11 @@
               </li>
             {{/if}}
             <li><a href="#" class="star-toggle-btn">{{starToggleMessage}}</a></li>
-
-            <li>
-              <a href="#" class="delete-btn">{{#t "delete"}}Delete{{/t}}</a>
-            </li>
+            {{#if can_delete}}
+              <li>
+                <a href="#" class="delete-btn">{{#t "delete"}}Delete{{/t}}</a>
+              </li>
+            {{/if}}
           </ul>
         </div>
       </li>

--- a/app/views/jst/conversations/messageItem.handlebars
+++ b/app/views/jst/conversations/messageItem.handlebars
@@ -66,9 +66,11 @@
             <li>
               <a href="#" class="forward-btn">{{#t "forward"}}Forward{{/t}}</a>
             </li>
-            <li>
-              <a href="#" class="delete-btn">{{#t "delete"}}Delete{{/t}}</a>
-            </li>
+            {{#if can_delete}}
+              <li>
+                <a href="#" class="delete-btn">{{#t "delete"}}Delete{{/t}}</a>
+              </li>
+            {{/if}}
           </ul>
         </div>
       </li>


### PR DESCRIPTION
### Tickets for this PR
 [PLAY-1007](https://strongmind.atlassian.net/browse/PLAY-1007)
[Related PR #105](https://github.com/StrongMind/canvas_shim/pull/105)
### Changes in this PR
- Added `CAN_DELETE_INBOX_MESSAGES` to js env to make available to inbox views
- Added check for permission for all views that include delete button in inbox