### PR TITLE
STK-1702: moved git:// to https:// for canvas_quizzes

### DIFF
--- a/client_apps/canvas_quizzes/package.json
+++ b/client_apps/canvas_quizzes/package.json
@@ -55,7 +55,7 @@
     "grunt-contrib-watch": "1.0.0",
     "grunt-jsduck": "1.0.1",
     "grunt-sass": "1.2.0",
-    "grunt-template-jasmine-requirejs": "git://github.com/amireh/grunt-template-jasmine-requirejs.git#0.2.0",
+    "grunt-template-jasmine-requirejs": "https://github.com/amireh/grunt-template-jasmine-requirejs.git#0.2.0",
     "jasmine_react": "1.2.4",
     "jasmine_rsvp": "1.0.0",
     "jasmine_xhr": "1.0.2",


### PR DESCRIPTION
the git protocol is no longer supported, switched it out for https.