### PR TITLE
QTY-474 Sentry Ignore ActiveRecord::RecordInvalid

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2509,7 +2509,7 @@ class UsersController < ApplicationController
         }
         # Intent is to verify whether or not the user is actually getting saved
         # when we send a 400.
-        puts ("User create attempted: @user.id: #{@user.id}")
+        puts ("User create attempted: @user.id: #{@user.inspect}")
         return render :json => errors, :status => :bad_request
       end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2507,9 +2507,6 @@ class UsersController < ApplicationController
             :observee => {}
           }
         }
-        # Intent is to verify whether or not the user is actually getting saved
-        # when we send a 400.
-        puts ("User create attempted: @user.id: #{@user.inspect}")
         return render :json => errors, :status => :bad_request
       end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2507,6 +2507,9 @@ class UsersController < ApplicationController
             :observee => {}
           }
         }
+        # Intent is to verify whether or not the user is actually getting saved
+        # when we send a 400.
+        puts ("User create attempted: @user.id: #{@user.id}")
         return render :json => errors, :status => :bad_request
       end
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -34,6 +34,7 @@ if settings.present?
     config.release = Canvas.revision
     config.enabled_environments = %w[ production ]
     config.excluded_exceptions += %w{
+      ActiveRecord::RecordInvalid
       AuthenticationMethods::AccessTokenError
       AuthenticationMethods::LoggedOutError
       ActionController::InvalidAuthenticityToken


### PR DESCRIPTION
Having sentry ignore this exception: This is to cut down on "exceptions" occurring that are actually normal application behavior. The HTTPS response from the server alerts the server of a 400 response already. Raising an exception as well is overly verbose and leads to alert fatigue/misinformation.