### PR TITLE
QTY-1034: preload big blue button conference recording data

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -173,11 +173,14 @@ class ConferencesController < ApplicationController
   def api_index(conferences)
     route = polymorphic_url([:api_v1, @context, :conferences])
     web_conferences = Api.paginate(conferences, self, route)
+    preload_recordings(web_conferences)
     render json: api_conferences_json(web_conferences, @current_user, session)
   end
   protected :api_index
 
   def web_index(conferences)
+    conferences = conferences.to_a
+    preload_recordings(conferences)
     @new_conferences, @concluded_conferences = conferences.partition { |conference|
       conference.ended_at.nil?
     }
@@ -385,5 +388,13 @@ class ConferencesController < ApplicationController
   def conference_params
     params.require(:web_conference).
       permit(:title, :duration, :description, :conference_type, :user_settings => strong_anything)
+  end
+
+  def preload_recordings(conferences)
+    conferences.group_by(&:class).each do |klass, klass_conferences|
+      if klass.respond_to?(:preload_recordings) # should only be BigBlueButton for now
+        klass.preload_recordings(klass_conferences)
+      end
+    end
   end
 end

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -97,6 +97,23 @@ describe ConferencesController do
       get 'index', params: {:course_id => @course.id}
       expect(assigns[:new_conferences]).to be_empty
     end
+
+    it "should preload recordings for BBB conferences" do
+      PluginSetting.create!(name: 'big_blue_button',
+        :settings => {
+          :domain => "bbb.totallyanexampleplzdontcallthis.com",
+          :secret_dec => "secret",
+        })
+      allow(BigBlueButtonConference).to receive(:send_request).and_return('')
+
+      user_session(@teacher)
+      @bbb = BigBlueButtonConference.create!(:title => "my conference", :user => @teacher, :context => @course)
+      @other = @course.web_conferences.create!(:conference_type => 'Wimba', :duration => 60, :user => @teacher)
+
+      expect(BigBlueButtonConference).to receive(:preload_recordings).with([@bbb])
+      get 'index', params: {:course_id => @course.id}
+      expect(response).to be_success
+    end
   end
 
   describe "POST 'create'" do

--- a/spec/fixtures/files/conferences/big_blue_button_get_recordings_bulk.json
+++ b/spec/fixtures/files/conferences/big_blue_button_get_recordings_bulk.json
@@ -1,0 +1,120 @@
+{
+  "returncode": "SUCCESS",
+  "recordings":
+  [
+    {
+      "recordID": "somerecordingidformeeting1a",
+      "meetingID": "instructure_web_conference_somemeetingkey1",
+      "name": "Conference Development 101",
+      "published": "true",
+      "protected": "false",
+      "startTime": "1513031612000",
+      "endTime": "1513031628000",
+      "metadata": {
+        "isBreakout": "false"
+      },
+      "playback":
+      [
+        {
+          "type": "statistics",
+          "url": "https://bbb.blah.com/instructure/ae094b1eb62b634c377fc255149de61a04ee8787-1521832370987/statistics/",
+          "length": null
+        },
+        {
+          "type": "presentation",
+          "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456/presentation/",
+          "length": "2",
+          "preview": {
+            "images":
+            [
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456/presentation/thumbnails/thumb-1.png",
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456/presentation/thumbnails/thumb-2.png",
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456/presentation/thumbnails/thumb-3.png"
+            ]
+          }
+        },
+        {
+          "type": "video",
+          "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456/capture/",
+          "length": "2"
+        }
+      ]
+    },
+    {
+      "recordID": "somerecordingidformeeting1b",
+      "meetingID": "instructure_web_conference_somemeetingkey1",
+      "name": "Conference Development 101",
+      "published": "true",
+      "protected": "false",
+      "startTime": "1513031142000",
+      "endTime": "1513031164000",
+      "metadata": {
+        "isBreakout": "false"
+      },
+      "playback":
+      [
+        {
+          "type": "statistics",
+          "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/statistics/",
+          "length": null
+        },
+        {
+          "type": "presentation",
+          "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/presentation/",
+          "length": "2",
+          "preview": {
+            "images":
+            [
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/presentation/thumbnails/thumb-1.png",
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/presentation/thumbnails/thumb-2.png",
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/presentation/thumbnails/thumb-3.png"
+            ]
+          }
+        },
+        {
+          "type": "video",
+          "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/capture/",
+          "length": "2"
+        }
+      ]
+    },
+    {
+      "recordID": "somerecordingidformeeting2",
+      "meetingID": "instructure_web_conference_somemeetingkey2",
+      "name": "Conference Development 101",
+      "published": "true",
+      "protected": "false",
+      "startTime": "1513031142000",
+      "endTime": "1513031164000",
+      "metadata": {
+        "isBreakout": "false"
+      },
+      "playback":
+      [
+        {
+          "type": "statistics",
+          "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/statistics/",
+          "length": null
+        },
+        {
+          "type": "presentation",
+          "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/presentation/",
+          "length": "2",
+          "preview": {
+            "images":
+            [
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/presentation/thumbnails/thumb-1.png",
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/presentation/thumbnails/thumb-2.png",
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/presentation/thumbnails/thumb-3.png"
+            ]
+          }
+        },
+        {
+          "type": "video",
+          "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/capture/",
+          "length": "2"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
[QTY-1034](https://strongmind.atlassian.net/browse/QTY-1034)

## Purpose
Increase performance of slow loading in Conferences page

## Approach
Use the same API method with multiple meeting ids to load all the recordings up in one go instead of making a bunch of individual calls

## Testing
We created about 250-500 conferences locally and in newidsandbox and measured performance before and after our fix. We also deployed to poes to test a real worst case scenario. Performance in poes went from 1.4 minutes to 11 seconds.

## Anything else
Passing methods to as_json executes the methods and includes the result and calling that method individually for each conference was the cause of poor performance.


(cherry picked from commit 82acf24eaac2d66fc79cc519c885329be40665c3)
Co-authored-by: Christopher Adeszko <christopher.adeszko@strongmind.com>