### PR TITLE
Revert "QTY-1136 added sentry delayed job gem"

### DIFF
--- a/Gemfile.d/app.rb
+++ b/Gemfile.d/app.rb
@@ -112,7 +112,6 @@ gem 'crocodoc-ruby', '0.0.1', require: false
 gem 'hey', '1.3.1', require: false
 gem 'sentry-rails', '5.3.1'
 gem 'sentry-ruby', '5.3.1'
-gem "sentry-delayed_job", '5.3.1'
 gem 'canvas_statsd', '2.0.4'
   gem 'statsd-ruby', '1.4.0', require: false
   gem 'aroi', '0.0.5', require: false


### PR DESCRIPTION
This reverts commit 5ae658895e721a2018fc3d5b87f9d40c3c664a52.