### PR TITLE
QTY-991: Upgrade to ruby 2.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@
 # these gems to prevent regression, and the indentation serves to alert us to the relationship between the gem and canvas-lms
 source 'https://rubygems.org/'
 
+RUBY_VERSION = "2.5"
+
 require File.expand_path("../config/canvas_rails5", __FILE__)
 
 Dir.glob(File.join(File.dirname(__FILE__), 'Gemfile.d', '*.rb')).sort.each do |file|

--- a/Gemfile.d/_before.rb
+++ b/Gemfile.d/_before.rb
@@ -23,12 +23,7 @@ if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('1.14.0') &&
   raise "Please run `gem update --system` to bring RubyGems to 2.6.9 or newer for use with Bundler 1.14 or newer."
 end
 
-# NOTE: this has to use 1.8.7 hash syntax to not raise a parser exception on 1.8.7
-if RUBY_VERSION >= "2.4.0" && RUBY_VERSION < "2.5"
-  ruby RUBY_VERSION, :engine => 'ruby', :engine_version => RUBY_VERSION
-else
-  ruby '2.4.0', :engine => 'ruby', :engine_version => '2.4.0'
-end
+ruby '2.5.0', :engine => 'ruby', :engine_version => '2.5.0'
 
 # force a different lockfile for rails 5.1
 unless CANVAS_RAILS5_0

--- a/Gemfile.d/_before.rb
+++ b/Gemfile.d/_before.rb
@@ -16,7 +16,7 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-gem 'bundler', '2.3.23'
+gem 'bundler', '2.3.24'
 
 if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('1.14.0') &&
   Gem::Version.new(Gem::VERSION) < Gem::Version.new('2.6.9')

--- a/Gemfile.d/_before.rb
+++ b/Gemfile.d/_before.rb
@@ -16,7 +16,7 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-gem 'bundler', '~> 2'
+gem 'bundler', '2.3.23'
 
 if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('1.14.0') &&
   Gem::Version.new(Gem::VERSION) < Gem::Version.new('2.6.9')

--- a/Gemfile.d/_before.rb
+++ b/Gemfile.d/_before.rb
@@ -23,7 +23,12 @@ if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('1.14.0') &&
   raise "Please run `gem update --system` to bring RubyGems to 2.6.9 or newer for use with Bundler 1.14 or newer."
 end
 
-ruby '2.5.0', :engine => 'ruby', :engine_version => '2.5.0'
+# NOTE: this has to use 1.8.7 hash syntax to not raise a parser exception on 1.8.7
+if RUBY_VERSION >= "2.4.0" && RUBY_VERSION <= "2.5"
+  ruby RUBY_VERSION, :engine => 'ruby', :engine_version => RUBY_VERSION
+else
+  ruby '2.4.0', :engine => 'ruby', :engine_version => '2.4.0'
+end
 
 # force a different lockfile for rails 5.1
 unless CANVAS_RAILS5_0

--- a/Gemfile.d/app.rb
+++ b/Gemfile.d/app.rb
@@ -169,3 +169,4 @@ gem 'canvas_shim', :path => 'vendor/canvas_shim'
 gem 'bootsnap', require: false
 gem 'jquery-rails'
 gem 'rails-ujs'
+gem 'rb-readline'

--- a/config/application.rb
+++ b/config/application.rb
@@ -182,7 +182,7 @@ module CanvasRails
 
     # safe_yaml can't whitelist specific instances of scalar values, so just override the loading
     # here, and do a weird check
-    YAML.add_ruby_type("object:Class") do |_type, val|
+    Psych.add_domain_type("ruby/object", "Class") do |_type, val|
       if SafeYAML.safe_parsing && !Canvas::Migration.valid_converter_classes.include?(val)
         raise "Cannot load class #{val} from YAML"
       end


### PR DESCRIPTION
[QTY-991](https://strongmind.atlassian.net/browse/QTY-991?atlOrigin=eyJpIjoiOTJmYWY1YWQ2MjlhNGY1MGFlMDdkMjAyNTU4NzNmZWMiLCJwIjoiaiJ9)

## Purpose 
Upgrade ruby from 2.4.10 to 2.5  for canvas-lms

## Approach 
ultimate goal here is to upgrade to the latest ruby version, doing so incrementally

## Testing
Built and tested locally

## Screenshots/Video
![image](https://user-images.githubusercontent.com/88393833/196746327-09106e09-2a7f-4ce3-a9df-80a18e17abc1.png)