### PR TITLE
QTY-1199 recurring calendar events feature flag adjustment

### DIFF
--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -242,9 +242,9 @@ END
       display_name: -> { I18n.t('Recurring Calendar Events') },
       description: -> { I18n.t("Allows the scheduling of recurring calendar events") },
       applies_to: 'Course',
-      state: 'hidden',
-      root_opt_in: true,
-      beta: true
+      state: 'on',
+      root_opt_in: false,
+      beta: false
     },
     'allow_opt_out_of_inbox' =>
     {

--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -242,7 +242,7 @@ END
       display_name: -> { I18n.t('Recurring Calendar Events') },
       description: -> { I18n.t("Allows the scheduling of recurring calendar events") },
       applies_to: 'Course',
-      state: 'on',
+      state: 'allowed',
       root_opt_in: false,
       beta: false
     },


### PR DESCRIPTION
[QTY-1199](https://strongmind.atlassian.net/browse/QTY-1199)

## Purpose
Teachers would like the ability to schedule recurring calendar events (calendar duplicates) so that they don’t have to create them each manually.

## Approach
We found that this feature already exists but is behind canvas’s feature flag system, however the flag was in beta, had opt-in required, and had a “hidden” status. We found that one teacher was unable to view the feature even if turned on. To make this visible for all users, we’ve set the following on the feature flag:
- don’t require opt-in
- set state to “allowed”
- set beta status to "false"

## Testing
We deployed our change to the sandbox environment and verified that all user roles can use the recurring calendar events feature.

## Screenshots (if applicable)
Before changes:
![image](https://user-images.githubusercontent.com/44770511/197575683-70c88d94-ddee-4088-8997-00bf5c08fad5.png)

After changes:
![image](https://user-images.githubusercontent.com/44770511/197575596-cb589736-1bb9-4b90-913c-8b9885b8268c.png)