### PR TITLE
QTY-814 add unique constraint on integration_id for Pseudonym

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2511,15 +2511,6 @@ class UsersController < ApplicationController
         # when we send a 400.
         puts ("User create attempted: @user.id: #{@user.inspect}")
         return render :json => errors, :status => :bad_request
-      rescue ActiveRecord::RecordNotUnique => e
-        errors = {
-          :errors => {
-            :user => @user.errors.as_json[:errors],
-            :pseudonym => @pseudonym.errors.as_json[:errors],
-          }
-        }
-        puts ("User already exists")
-        return render :json => errors, :status => :conflict
       end
 
       if @observee && !@user.user_observees.where(user_id: @observee).exists?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2511,6 +2511,15 @@ class UsersController < ApplicationController
         # when we send a 400.
         puts ("User create attempted: @user.id: #{@user.inspect}")
         return render :json => errors, :status => :bad_request
+      rescue ActiveRecord::RecordNotUnique => e
+        errors = {
+          :errors => {
+            :user => @user.errors.as_json[:errors],
+            :pseudonym => @pseudonym.errors.as_json[:errors],
+          }
+        }
+        puts ("User already exists")
+        return render :json => errors, :status => :conflict
       end
 
       if @observee && !@user.user_observees.where(user_id: @observee).exists?

--- a/app/models/pseudonym.rb
+++ b/app/models/pseudonym.rb
@@ -35,6 +35,7 @@ class Pseudonym < ActiveRecord::Base
   validates_length_of :sis_user_id, :maximum => maximum_string_length, :allow_blank => true
   validates_presence_of :account_id
   validate :must_be_root_account
+  validates :integration_id, uniqueness: true
   # allows us to validate the user and pseudonym together, before saving either
   validates_each :user_id do |record, attr, value|
     record.errors.add(attr, "blank?") unless value || record.user


### PR DESCRIPTION
[QTY-418](https://strongmind.atlassian.net/browse/QTY-814)

## Purpose
We get ActiveRecord::RecordNotUnique when posting updates on users. This post leads to an update on Pseudonyms which has an index on it that makes integration_id a unique constraint (it tries to create a duplicate key in that index).

## Approach
We added the integration_id as a unique constraint on the Pseudonym model so that it becomes a part of validation. When we run into this error, it will get rescued and notify us with a 409 Conflict error status.

## Testing
We created a user through postman and then tried to create another user with the same integration_id. We tested this locally and in newidsandbox.

## Screenshots (if applicable)
Note we have a detailed error: integration_id is taken
![314B2BDD-8E56-4039-87A3-6B7D66F306A5](https://user-images.githubusercontent.com/87540376/199067905-44451ebc-03e9-47ab-9cea-1e752f5d1922.jpeg)