### PR TITLE
QTY-1278

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2838,7 +2838,8 @@ class Course < ActiveRecord::Base
         # hash the unique_id so that it's hard to accidently enroll the user in
         # a course by entering something in a user list. :(
         fake_student.pseudonyms.create!(:account => self.root_account,
-                                        :unique_id => Canvas::Security.hmac_sha1("Test Student_#{fake_student.id}"))
+                                        :unique_id => Canvas::Security.hmac_sha1("Test Student_#{fake_student.id}"),
+                                        :integration_id => SecureRandom.uuid)
       end
       fake_student
     else

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -156,6 +156,7 @@ class Enrollment < ActiveRecord::Base
   end
 
   def touch_assignments
+    return if self.fake_student?
     Assignment.
       where(context_id: course_id, context_type: 'Course').
       where("EXISTS (?) AND NOT EXISTS (?)",


### PR DESCRIPTION
[QTY-1278](https://strongmind.atlassian.net/browse/QTY-1278)

## Purpose
Student view was broken due to an update to the Pseudonym model where we put a unique constraint on the integration_id. When a teacher/admin uses student view, a new test user pseudonym was being created with integration_id as nil, so we had multiple test user pseudonyms with matching integration ids.

## Approach
When the Pseudonym is created, generate a random integration_id.

Ignore touch_assignments for test users, because that is triggered automatically when a student is changed to update the "needs grading" count. We don't care about grading for our test users (test user isn't actually enrolled in the course).

## Testing
Tested locally and in newidsandbox. Also tested the "reset student" feature in student view to make sure it still works (stduent view allows you to test module progression / sequence control, and you can "reset student" to undo all progression for the test student and start from the beginning of the course).