### PR TITLE
QTY-1414: downgrade ruby from 2.6.10 to 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@
 # these gems to prevent regression, and the indentation serves to alert us to the relationship between the gem and canvas-lms
 source 'https://rubygems.org/'
 
-RUBY_VERSION = "2.6.10"
+RUBY_VERSION = "2.5"
 
 require File.expand_path("../config/canvas_rails5", __FILE__)
 


### PR DESCRIPTION
[QTY-1413](https://strongmind.atlassian.net/browse/QTY-1413)

#Delete comments under headings and replace with appropriate descriptions for each category

## Purpose 
downgrade ruby from 2.6.10 to 2.5, there were more incompatibilities found on thursday with ruby 2.6.

## Approach 
downrade using deps and gemfile

## Testing
We rolled out this image thursday night.
