### PR TITLE
QTY-1410: create local dev env without docker

### DIFF
--- a/Gemfile.d/app.rb
+++ b/Gemfile.d/app.rb
@@ -3,6 +3,7 @@
 #
 # This file is part of Canvas.
 #
+#
 # Canvas is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Affero General Public License as published by the Free
 # Software Foundation, version 3 of the License.
@@ -14,6 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License along
 # with this program. If not, see <http://www.gnu.org/licenses/>.
+gem 'dotenv-rails', :groups => [:development, :test]
 
 if CANVAS_RAILS5_0
   gem 'rails', '5.0.7.2'
@@ -62,7 +64,7 @@ gem 'canvas_webex', '0.17'
 gem 'inst-jobs', '0.13.5'
   gem 'rufus-scheduler', '3.4.2', require: false
     gem 'et-orbi', '1.0.5', require: false
-gem 'ffi', '1.9.18', require: false
+gem 'ffi', '1.15.4', require: false
 gem 'hashery', '2.1.2', require: false
 gem 'highline', '1.7.8', require: false
 gem 'httparty', '0.15.6'

--- a/Gemfile.d/app.rb
+++ b/Gemfile.d/app.rb
@@ -15,7 +15,6 @@
 #
 # You should have received a copy of the GNU Affero General Public License along
 # with this program. If not, see <http://www.gnu.org/licenses/>.
-gem 'dotenv-rails', :groups => [:development, :test]
 
 if CANVAS_RAILS5_0
   gem 'rails', '5.0.7.2'
@@ -173,3 +172,4 @@ gem 'jquery-rails'
 gem 'rails-ujs'
 gem 'rb-readline'
 gem 'launchdarkly-server-sdk', '~> 6.0.0'
+gem 'dotenv-rails', :groups => [:development, :test]

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,9 +1,0 @@
-# StrongMind Added
-web: bundle exec thin start
-webpack: yarn run webpack
-worker: bundle exec script/delayed_job run
-echo: ruby echo_server.rb
-# css: yarn run build:css:watch
-
-# You can use Puma if you like
-# puma -C config/puma.rb

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,4 @@
+
 #
 # Copyright (C) 2013 - present Instructure, Inc.
 #
@@ -101,6 +102,10 @@ module CanvasRails
         end
 
         config.logger = CanvasLogger.new(log_path, log_level, opts)
+    end
+
+    if ['development', 'test'].include? ENV['RAILS_ENV']
+      Dotenv.load('canvas.env')
     end
 
     # Activate observers that should always be running

--- a/config/initializers/launch_darkly.rb
+++ b/config/initializers/launch_darkly.rb
@@ -1,1 +1,1 @@
-Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new(ENV['LAUNCH_DARKLY_SDK_KEY'])
+Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new(sdk_key: ENV['LAUNCH_DARKLY_SDK_KEY'])

--- a/config/initializers/launch_darkly.rb
+++ b/config/initializers/launch_darkly.rb
@@ -1,1 +1,1 @@
-Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new(sdk_key: ENV['LAUNCH_DARKLY_SDK_KEY'])
+Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new(ENV['LAUNCH_DARKLY_SDK_KEY'])

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -47,7 +47,7 @@ workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
 # write out a pid file
-pidfile '/var/run/puma.pid'
+pidfile './tmp/puma.pid'
 
 on_worker_boot do
   Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new(ENV['LAUNCH_DARKLY_SDK_KEY'])

--- a/config/security.yml
+++ b/config/security.yml
@@ -1,9 +1,8 @@
-production:
-  # replace this with a random string of at least 20 characters
-  encryption_key: <%= ENV['ENCRYPTION_KEY'] %>
+production: &default
+  encryption_key: <%= ENV["ENCRYPTION_KEY"] %>
 
 development:
-  encryption_key: <%= ENV['ENCRYPTION_KEY'] %>
+  <<: *default
 
 test:
-  encryption_key: <%= ENV['ENCRYPTION_KEY'] %>
+  <<: *default

--- a/procfile
+++ b/procfile
@@ -1,3 +1,2 @@
 web:	 RAILS_ENV=development bundle exec rails s
 worker:  RAILS_ENV=development bundle exec script/delayed_job run
-echo: ruby echo_server.rb

--- a/procfile
+++ b/procfile
@@ -1,2 +1,2 @@
-web:	bundle exec rails s
-worker: bundle exec script/delayed_job run
+web:	RAILS_ENV=development bundle exec rails s
+worker: RAILS_ENV=development bundle exec script/delayed_job run

--- a/procfile
+++ b/procfile
@@ -1,0 +1,2 @@
+web:	bundle exec rails s
+worker: bundle exec script/delayed_job run

--- a/procfile
+++ b/procfile
@@ -1,2 +1,2 @@
-web:	 RAILS_ENV=development bundle exec rails s
+web: 	 RAILS_ENV=development PORT=3000 bundle exec rails server
 worker:  RAILS_ENV=development bundle exec script/delayed_job run

--- a/procfile
+++ b/procfile
@@ -1,2 +1,3 @@
-web:	RAILS_ENV=development bundle exec rails s
-worker: RAILS_ENV=development bundle exec script/delayed_job run
+web:	 RAILS_ENV=development bundle exec rails s
+worker:  RAILS_ENV=development bundle exec script/delayed_job run
+echo: ruby echo_server.rb


### PR DESCRIPTION
[QTY-1410](https://strongmind.atlassian.net/browse/QTY-1410)

## Purpose 
create a local dev env that supports no docker

## Approach 
create a docker compose file for local, which only runs support services. Foreman is used to start/stop the web & worker

## Testing
tested on two separate machines
