### PR TITLE
QTY-1583: moved integration_id validation to canvas shim

### DIFF
--- a/app/models/pseudonym.rb
+++ b/app/models/pseudonym.rb
@@ -35,7 +35,6 @@ class Pseudonym < ActiveRecord::Base
   validates_length_of :sis_user_id, :maximum => maximum_string_length, :allow_blank => true
   validates_presence_of :account_id
   validate :must_be_root_account
-  validates :integration_id, uniqueness: true
   # allows us to validate the user and pseudonym together, before saving either
   validates_each :user_id do |record, attr, value|
     record.errors.add(attr, "blank?") unless value || record.user

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "sanitize.css": "^5.0.0",
     "strongmind-icons": "6.0.1",
     "styled-components": "^2.4.0",
-    "tinymce": "5.10.7"
+    "tinymce": "4.5.7"
   },
   "devDependencies": {
     "axe-core": "2.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8375,12 +8375,7 @@ tinymce-light-skin@1.3.1, tinymce-light-skin@~1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/tinymce-light-skin/-/tinymce-light-skin-1.3.1.tgz#fcce7a8b5761716a381f756e1ac7f47c7a41ea88"
 
-tinymce@5.10.7:
-  version "5.10.7"
-  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-5.10.7.tgz#d89d446f1962f2a1df6b2b70018ce475ec7ffb80"
-  integrity sha512-9UUjaO0R7FxcFo0oxnd1lMs7H+D0Eh+dDVo5hKbVe1a+VB0nit97vOqlinj+YwgoBDt6/DSCUoWqAYlLI8BLYA==
-
-tinymce@~4.5.7:
+tinymce@4.5.7, tinymce@~4.5.7:
   version "4.5.7"
   resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-4.5.7.tgz#e1f5cd286ec3c9977bd672a4c14e496f63bc4fef"
 


### PR DESCRIPTION
[QTY-1583](https://strongmind.atlassian.net/browse/QTY-1583)

## Purpose 
We added a uniqueness check to the integration id a few weeks ago, this introduced a problem when trying to create a new pseudonym with nil values for integration ids. it meant that only one pseudonym could exist with nil for the integration id.

## Approach 
i've moved the validation to the canvas shim where i think it should've been placed initially.

## Testing
added a spec to test whether or not a Pseudonym is valid when integration is nil. also ran locally to verify that i can now create new users from the users ui in canvas. (previously wasn't working)
