### PR TITLE
QTY-814 update validation on unique_id for Pseudonym creation

### DIFF
--- a/app/models/pseudonym.rb
+++ b/app/models/pseudonym.rb
@@ -222,8 +222,8 @@ class Pseudonym < ActiveRecord::Base
     unless self.deleted?
       self.shard.activate do
         existing_pseudo = Pseudonym.active.by_unique_id(self.unique_id).where(:account_id => self.account_id,
-          :authentication_provider_id => self.authentication_provider_id).first
-        if existing_pseudo && existing_pseudo.id != self.id
+          :authentication_provider_id => self.authentication_provider_id).exists?
+        if existing_pseudo
           self.errors.add(:unique_id, :taken,
             message: t("ID already in use for this account and authentication provider"))
           throw :abort


### PR DESCRIPTION
Co-authored-by: Alexandra Davis <alexandra.davis@strongmind.com>

[QTY-814](https://strongmind.atlassian.net/browse/QTY-814)

## Purpose 
We are getting ActiveRecord::RecordNotUnique errors on creation of User/Pseudonym because of an index that uses unique_id as a key.

## Approach 
We updated the validation for unique_id to match what is currently in instructure's code.

## Testing
We tested this in new-id-sandbox by creating a user in rails console and then tried to create the same user with the same unique_id and we were able to see our error ("ID already in use for this account and authentication provider").