### PR TITLE
QTY-1599: Add Threshold settings for all assignment groups at the course level

### DIFF
--- a/app/models/assignment_group.rb
+++ b/app/models/assignment_group.rb
@@ -42,6 +42,11 @@ class AssignmentGroup < ActiveRecord::Base
   after_save :update_student_grades
 
   GROUP_NAMES = [ 'Assignment', 'Checkpoint', 'Close Reading Project', 'Discussion', 'Exam', 'Final Exam', 'Pretest', 'Project', 'Workbook' ].freeze
+
+  def self.passing_threshold_group_names
+    GROUP_NAMES.map{|n| n.downcase.gsub(/\s/, "_")}
+  end
+
   def generate_default_values
     if self.name.blank?
       self.name = t 'default_title', "Assignments"

--- a/public/javascripts/context_modules.js
+++ b/public/javascripts/context_modules.js
@@ -1575,10 +1575,10 @@ import 'compiled/jquery.rails_flash_notifications'
               modules.updateAssignmentData();
               modules.loadMasterCourseData(data.content_tag.id);
             }), { onComplete: function() {
-              if (ENV['score_threshold'] && ['assignment', 'discussion_topic', 'quiz'].includes(item_data['item[type]'])) {
+              if (ENV['passing_thresholds'][item_data['item[type]'].split('_')[0]] !== undefined && ['assignment'].includes(item_data['item[type]'])) {
                 var score = $item.find('.min_score_requirement .unfulfilled');
                 score.parents().show();
-                score.text(`Score at least ${ENV['score_threshold']}`);
+                score.text(`Score at least ${ENV['passing_thresholds'][item_data['item[type]'].split('_')[0]]}`);
 
                 if (modules.checkForExisting(item_data['item[type]'], item_data['item[id]'])) {
                   score.prepend('<span style="margin-left: -.5rem; padding-right: 1.25rem;">|</span>');


### PR DESCRIPTION
[QTY-1599](https://strongmind.atlassian.net/browse/QTY-1599)

## Purpose 

Allow school personnel to set passing thresholds at the course-level, which take precedence over the account-level passing thresholds (added by [this PR](https://github.com/StrongMind/canvas_shim/pull/412)), if set. 

## Approach 

Update course settings page to have fields for a pre-determined set of assignment groups, replacing the existing threshold fields for assignments and exams.

Utilize AssignmentGroup::GROUP_NAMES constant added by the previous PR to determine which assignment groups we will support passing thresholds for by default.

Utilizes the existing RequirementsService and SettingsService to dynamically get and set thresholds for the supported assignment groups.

Updates the checks in `context_modules_controller_decorator.rb` to check for thresholds for the newly supported groups at the course level.

Updates `courses_controller_decorator.rb` to get/set thresholds at the course level for the newly supported assignment groups. Adds some helper methods (`determine_assignment_group_overrides` and `set_assignment_group_threshold_overrides`) to determine which assignment groups have been overridden at the course level and set an additional setting on the course, `assignment_group_threshold_overrides`, so that it is not overridden by an account level update. 

Updates the callback in `account_decorator.rb`, `context_module_decorator.rb` to respect the course level assignment group overrides. 

Adds a helper method for the assignment group names in `assignment_group_decorator.rb`

Updates to the `requirements_service`, `force_min_scores` to respect assignment group name thresholds. 

Updates the `course` pipeline serializer to pass all of the new assignment group thresholds data to the pipeline.

Adds `apply_assignment_group_min_scores` class (based on the previously used `apply_assignment_min_scores` and `apply_unit_exam_min_scores` to handle much of the logic for determining how and when thresholds are updated. 

Remove references to `unit_exam` as they are no longer handled as a special case. 

Update existing specs to be in line with new functionality. Added a couple of factories to support testing. 

## Testing

Tested locally and on newidsandbox. To confirm thresholds are set and updated as expected some example steps might be:

1. Set thresholds on account settings page
2. Create a new course and import a cartridge, verify that the thresholds set are applied to the course settings page and assignments based on the content's assignment group
3. Edit an assignments assignment group, verify that the threshold changed as appropriate
4. Edit the course level thresholds, verify that content within the course has threshold updated as appropriate
5. Manually create an assignment and a discussion topic (since they are created differently) and verify that both have the appropriate thresholds set (DiscussionTopic will not have a threshold set until marked as graded as that is when it has an associated assignment created and therefor an assignment group threshold to associate)
6. Create courses with a start date in the past and one in the future
7. Change the thresholds set in account settings
8. Verify that the course with a past start date is not affected but the course with the future start date reflects the new thresholds
9. Verify that courses which have passing thresholds overridden are not affected by the change at the account level but that course level thresholds which match the account level setting are updated. 

## Screenshots/Video

<img width="1269" alt="image" src="https://user-images.githubusercontent.com/30609917/208202575-ab10fd97-15f2-47aa-b576-f67af44bb764.png">

