### PR TITLE
QTY-1347

### DIFF
--- a/app/stylesheets/pages/account_settings/_account_settings.scss
+++ b/app/stylesheets/pages/account_settings/_account_settings.scss
@@ -157,7 +157,7 @@
     }
     &.small-select{
       select {
-        width: 30px;
+        width: 60px;
       }
     }
     input.same-width-as-select {

--- a/app/stylesheets/pages/account_settings/_account_settings.scss
+++ b/app/stylesheets/pages/account_settings/_account_settings.scss
@@ -155,6 +155,11 @@
     select {
       width: 280px;
     }
+    &.small-select{
+      select {
+        width: 30px;
+      }
+    }
     input.same-width-as-select {
       width: 265px;
     }


### PR DESCRIPTION
[QTY-1347](https://strongmind.atlassian.net/browse/QTY-1347)

## Purpose 
To add a new account setting that allows schools to choose a course start time. This will ensure that courses coming from powerschool will start on their specified date at the time that they desire. They can make the change in the account settings page. This will be a time picker in a new section called "Default Course Start Time".

## Approach 
We used a date/time picker helper that lives in the account settings (settings.html.rb). The values that the user chooses get stored in the school settings table (SettingsService.get_settings(object: 'school', id: 1)). In the course model, for any newly created courses, we update the start_at time to the values that are set in this setting. This feature currently sits behind a launch darkly flag.

## Testing
We tested this locally and time picker works as expected (can select hour/minute and AM/PM). We turned the flag on and off and the features shows/hides accordingly.

## Screenshots/Video
<img width="274" alt="image" src="https://user-images.githubusercontent.com/87540376/211378524-e8d9fcb8-d1b3-491f-9040-bc1e9246977d.png">


[QTY-1347]: https://strongmind.atlassian.net/browse/QTY-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ