### PR TITLE
QTY-1802

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2265,13 +2265,14 @@ class ApplicationController < ActionController::Base
 
   def launch_darkly_user
     domain = ENV['SETTINGS_TABLE_PREFIX']
-    {
-      key: "#{domain.split('.')[0]}-#{@current_user.id}",
-      name: @current_user.name,
-      custom: {
-        canvas_id: @current_user.id,
-        canvas_domain: domain,
-      }
-    }
+    @launch_darkly_user = {
+                            key: "#{domain.split('.')[0]}-#{@current_user.id}",
+                            name: @current_user.name,
+                            custom: {
+                              canvas_id: @current_user.id,
+                              canvas_domain: domain,
+                            }
+                          }
   end
+  before_action :launch_darkly_user
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2274,5 +2274,5 @@ class ApplicationController < ActionController::Base
                             }
                           }
   end
-  before_action :launch_darkly_user
+  before_action :launch_darkly_user, if: Proc.new { @current_user.present? }
 end


### PR DESCRIPTION
[QTY-1802](https://strongmind.atlassian.net/browse/QTY-1802)

## Purpose 
Alerts for submission of a guided practice were recently released to enterprise canvas without a launch darkly flag. In order to gradually roll out the feature to end users, we created a launch darkly flag and updated the source code to use the flag for guided practice submitted alerts. 

## Approach 
Updated the `launch_darkly_user` method in `application_controller.rb` to run in a `before_action` callback. Updated the method to set `@launch_darkly_user` variable for use throughout the application. Conditionalized the `before_action` callback to only run the method if a user is present to prevent no method errors. 

## Testing
- With feature flag off:
1. As a student, create a guided practice submission for a course
2. As the teacher for that course, confirm that no `guided practice submitted` alert was created and appearing in the dashboard. 
- With feature flag on:
1. As a student, create a guided practice submission for a course
2. As the teacher for that course, confirm that a `guided practice submitted` alert was created and appearing in the dashboard. 

[QTY-1802]: https://strongmind.atlassian.net/browse/QTY-1802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ