### PR TITLE
QTY-1504 prevent cheating for graded discussion topics when user must post before viewing all posts

### DIFF
--- a/app/controllers/discussion_topics_api_controller.rb
+++ b/app/controllers/discussion_topics_api_controller.rb
@@ -106,7 +106,8 @@ class DiscussionTopicsApiController < ApplicationController
     mobile_brand_config = !in_app? && @context.account.effective_brand_config
     opts = {
       :include_new_entries => value_to_boolean(params[:include_new_entries]),
-      :include_mobile_overrides => !!mobile_brand_config
+      :include_mobile_overrides => !!mobile_brand_config,
+      :user_id => @current_user.id
     }
     structure, participant_ids, entry_ids, new_entries = @topic.materialized_view(opts)
 

--- a/app/controllers/discussion_topics_api_controller.rb
+++ b/app/controllers/discussion_topics_api_controller.rb
@@ -107,7 +107,8 @@ class DiscussionTopicsApiController < ApplicationController
     opts = {
       :include_new_entries => value_to_boolean(params[:include_new_entries]),
       :include_mobile_overrides => !!mobile_brand_config,
-      :user_id => @current_user.id
+      :user_id => @current_user.id, 
+      :launch_darkly_user => @launch_darkly_user
     }
     structure, participant_ids, entry_ids, new_entries = @topic.materialized_view(opts)
 

--- a/app/models/discussion_topic/materialized_view.rb
+++ b/app/models/discussion_topic/materialized_view.rb
@@ -79,12 +79,14 @@ class DiscussionTopic::MaterializedView < ActiveRecord::Base
     if !up_to_date?
       update_materialized_view
     end
+    
+    json_structure ||= opts[:json_structure]
+    entry_ids ||= opts[:entry_ids]
 
     if json_structure.present?
       participant_ids = self.participants_array
-      entry_ids = self.entry_ids_array
 
-      if opts[:include_new_entries]
+      if opts[:include_new_entries] && opts[:show_other_users_submissions]
         @for_mobile = true if opts[:include_mobile_overrides]
 
         new_entries = all_entries.count != entry_ids.count ? all_entries.where.not(:id => entry_ids).to_a : []
@@ -95,7 +97,7 @@ class DiscussionTopic::MaterializedView < ActiveRecord::Base
         new_entries_json_structure = []
       end
 
-      return self.json_structure, participant_ids, entry_ids, new_entries_json_structure
+      return json_structure, participant_ids, entry_ids, new_entries_json_structure
     else
       return nil
     end


### PR DESCRIPTION
[QTY-1504](https://strongmind.atlassian.net/browse/QTY-1504)

## Purpose 
Discussion topics have an optional setting that prevents students from viewing posts until they have contributed to the thread. Before this change, students were bypassing this by posting garbage values as a post, viewing other student's posts, and cheating off of their peers. To prevent cheating, we've updated this setting to not only require students to contribute, but to receive a grade for their post, before they can view their peer's contributions (this sits behind a launch darkly flag).

## Approach 
We extended the **materialized_view.rb** by adding a decorator **materialized_view_decorator.rb** which will prevent posts from rendering unless the student viewing the discussion topic has posted and that post has been graded. These checks only run for graded discussions topics (graded discussion check was added to **discussion_topic_decorator.rb**). The original functionality will be maintained for discussion topics that aren't graded. New functionality sits behind launch darkly flag (**expose-discussion-entries-only-if-graded-submission-exists**).

## Testing
We tested this both locally and in new-id-sandbox, testing that the expected behavior below was true:

When launch darkly flag is ON:
- Admin/teacher can still view all posts in discussion
- Student who has submitted a post that hasn't been graded **cannot** view other posts
- Student who has submitted a post that has been graded **can** view other posts
- Student who hasn't submitted anything **cannot** view other posts

When launch darkly flag is OFF:
- Admin/teacher can still view all posts in discussion
- Student who has submitted a post, graded or not, **can** view other posts
- Students who haven't submitted anything **cannot** view other posts

## Screenshots/Video
Nothing has changed in the UI, but our new functionality (additional checks for cheating) will happen if the following discussion board settings are checked and the launch darkly flag is on.

<img width="421" alt="image" src="https://user-images.githubusercontent.com/87540376/215540834-2e9bfb70-926d-44df-9fed-3672e9911054.png">

[QTY-1504]: https://strongmind.atlassian.net/browse/QTY-1504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Video Demo:
https://user-images.githubusercontent.com/87540376/215614344-b0e0f99a-25c0-4817-8cdb-4fc64b40fc05.mov

