### PR TITLE
QTY-1807

### DIFF
--- a/app/controllers/context_modules_controller.rb
+++ b/app/controllers/context_modules_controller.rb
@@ -79,6 +79,9 @@ class ContextModulesController < ApplicationController
       if @context && @current_user && enrollment = StudentEnrollment.find_by(course_id: @context.id, user_id: @current_user.id)
         settings = SettingsService.get_enrollment_settings(id: enrollment.id)
         sequence_control = false if !settings["sequence_control"].nil? && settings["sequence_control"] == false
+        if Account.first.name == 'Primavera Online High School'
+          sequence_control = false
+        end
       end
 
 

--- a/app/controllers/context_modules_controller.rb
+++ b/app/controllers/context_modules_controller.rb
@@ -79,7 +79,6 @@ class ContextModulesController < ApplicationController
       if @context && @current_user && enrollment = StudentEnrollment.find_by(course_id: @context.id, user_id: @current_user.id)
         settings = SettingsService.get_enrollment_settings(id: enrollment.id)
         sequence_control = false if !settings["sequence_control"].nil? && settings["sequence_control"] == false
-        sequence_control = false
       end
 
 
@@ -639,10 +638,6 @@ class ContextModulesController < ApplicationController
         render :json => @module.errors, :status => :bad_request
       end
     end
-
-    puts "#################"
-    puts @current_user.inspect
-    puts "#################"
   end
 
   def destroy

--- a/app/controllers/context_modules_controller.rb
+++ b/app/controllers/context_modules_controller.rb
@@ -79,7 +79,7 @@ class ContextModulesController < ApplicationController
       if @context && @current_user && enrollment = StudentEnrollment.find_by(course_id: @context.id, user_id: @current_user.id)
         settings = SettingsService.get_enrollment_settings(id: enrollment.id)
         sequence_control = false if !settings["sequence_control"].nil? && settings["sequence_control"] == false
-        if Account.first.name == 'Primavera Online High School'
+        if Account.first.name == 'Primavera Online High School' || 'iSucceed Virtual High School'
           sequence_control = false
         end
       end

--- a/app/controllers/context_modules_controller.rb
+++ b/app/controllers/context_modules_controller.rb
@@ -79,9 +79,7 @@ class ContextModulesController < ApplicationController
       if @context && @current_user && enrollment = StudentEnrollment.find_by(course_id: @context.id, user_id: @current_user.id)
         settings = SettingsService.get_enrollment_settings(id: enrollment.id)
         sequence_control = false if !settings["sequence_control"].nil? && settings["sequence_control"] == false
-        if Account.first.name == 'Primavera Online High School'
-          sequence_control = false
-        end
+        sequence_control = false
       end
 
 

--- a/app/controllers/context_modules_controller.rb
+++ b/app/controllers/context_modules_controller.rb
@@ -79,7 +79,7 @@ class ContextModulesController < ApplicationController
       if @context && @current_user && enrollment = StudentEnrollment.find_by(course_id: @context.id, user_id: @current_user.id)
         settings = SettingsService.get_enrollment_settings(id: enrollment.id)
         sequence_control = false if !settings["sequence_control"].nil? && settings["sequence_control"] == false
-        if Account.first.name == 'Primavera Online High School' || 'iSucceed Virtual High School'
+        if Account.first.name == 'Primavera Online High School'
           sequence_control = false
         end
       end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1652,7 +1652,7 @@ class CoursesController < ApplicationController
       current_user_enrollment = @current_user.not_ended_enrollments.find_by(type: "StudentEnrollment", course: @context)
       if current_user_enrollment
         current_user_settings = SettingsService.get_enrollment_settings(id: current_user_enrollment.id)
-        if Account.first.name == 'Primavera Online High School'
+        if Account.first.name == 'Primavera Online High School' || 'iSucceed Virtual High School'
           sequence_control = false
         else
           sequence_control = current_user_settings.fetch('sequence_control', true)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1645,18 +1645,13 @@ class CoursesController < ApplicationController
       return
     end
 
-
     @context = api_find(Course.active, params[:id])
 
     if @context && @current_user
       current_user_enrollment = @current_user.not_ended_enrollments.find_by(type: "StudentEnrollment", course: @context)
       if current_user_enrollment
         current_user_settings = SettingsService.get_enrollment_settings(id: current_user_enrollment.id)
-        if Account.first.name == 'Primavera Online High School'
-          sequence_control = false
-        else
-          sequence_control = current_user_settings.fetch('sequence_control', true)
-        end
+        sequence_control = current_user_settings.fetch('sequence_control', true)
         if sequence_control
           @current_requirement = CourseProgress.new(@context, @current_user).current_content_tag
         end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1652,7 +1652,11 @@ class CoursesController < ApplicationController
       current_user_enrollment = @current_user.not_ended_enrollments.find_by(type: "StudentEnrollment", course: @context)
       if current_user_enrollment
         current_user_settings = SettingsService.get_enrollment_settings(id: current_user_enrollment.id)
-        sequence_control = current_user_settings.fetch('sequence_control', true)
+        if Account.first.name == 'Primavera Online High School'
+          sequence_control = false
+        else
+          sequence_control = current_user_settings.fetch('sequence_control', true)
+        end
         if sequence_control
           @current_requirement = CourseProgress.new(@context, @current_user).current_content_tag
         end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1652,7 +1652,7 @@ class CoursesController < ApplicationController
       current_user_enrollment = @current_user.not_ended_enrollments.find_by(type: "StudentEnrollment", course: @context)
       if current_user_enrollment
         current_user_settings = SettingsService.get_enrollment_settings(id: current_user_enrollment.id)
-        if Account.first.name == 'Primavera Online High School' || 'iSucceed Virtual High School'
+        if Account.first.name == 'Primavera Online High School'
           sequence_control = false
         else
           sequence_control = current_user_settings.fetch('sequence_control', true)

--- a/app/models/assignment/speed_grader.rb
+++ b/app/models/assignment/speed_grader.rb
@@ -228,7 +228,7 @@ class Assignment
             end
           end
         elsif @assignment.quiz && sub.quiz_submission
-          json['submission_history'] = qs_versions[sub.quiz_submission.id].map do |v|
+          json['submission_history'] = qs_versions[sub.quiz_submission.id]&.map do |v|
             # don't use v.model, because these are huge objects, and can be significantly expensive
             # to instantiate an actual AR object deserializing and reserializing the inner YAML
             qs = YAML.load(v.yaml)

--- a/app/models/context_module.rb
+++ b/app/models/context_module.rb
@@ -259,7 +259,7 @@ class ContextModule < ActiveRecord::Base
 
     if enrollment
       settings = enrollment ? SettingsService.get_enrollment_settings(id: enrollment.id) : {}
-      if Account.first.name == 'Primavera Online High School'
+      if Account.first.name == 'Primavera Online High School' || 'iSucceed Virtual High School'
         sequence_control = false
       else
         sequence_control = settings.fetch('sequence_control', true)

--- a/app/models/context_module.rb
+++ b/app/models/context_module.rb
@@ -259,11 +259,7 @@ class ContextModule < ActiveRecord::Base
 
     if enrollment
       settings = enrollment ? SettingsService.get_enrollment_settings(id: enrollment.id) : {}
-      if Account.first.name == 'Primavera Online High School'
-        sequence_control = false
-      else
-        sequence_control = settings.fetch('sequence_control', true)
-      end
+      sequence_control = settings.fetch('sequence_control', true)
       return true unless sequence_control
     end
 

--- a/app/models/context_module.rb
+++ b/app/models/context_module.rb
@@ -259,7 +259,11 @@ class ContextModule < ActiveRecord::Base
 
     if enrollment
       settings = enrollment ? SettingsService.get_enrollment_settings(id: enrollment.id) : {}
-      sequence_control = settings.fetch('sequence_control', true)
+      if Account.first.name == 'Primavera Online High School'
+        sequence_control = false
+      else
+        sequence_control = settings.fetch('sequence_control', true)
+      end
       return true unless sequence_control
     end
 

--- a/app/models/context_module.rb
+++ b/app/models/context_module.rb
@@ -259,7 +259,7 @@ class ContextModule < ActiveRecord::Base
 
     if enrollment
       settings = enrollment ? SettingsService.get_enrollment_settings(id: enrollment.id) : {}
-      if Account.first.name == 'Primavera Online High School' || 'iSucceed Virtual High School'
+      if Account.first.name == 'Primavera Online High School'
         sequence_control = false
       else
         sequence_control = settings.fetch('sequence_control', true)

--- a/app/models/discussion_entry.rb
+++ b/app/models/discussion_entry.rb
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU Affero General Public License along
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-require 'timeout'
 require 'atom'
 
 class DiscussionEntry < ActiveRecord::Base
@@ -347,7 +346,7 @@ class DiscussionEntry < ActiveRecord::Base
 
   def context_module_action
     if self.discussion_topic && self.user
-      Timeout.timeout(7.minutes.to_i, Timeout::Error) { self.discussion_topic.context_module_action(user, :contributed) }
+      self.discussion_topic.context_module_action(user, :contributed)
     end
   end
 

--- a/app/models/discussion_entry.rb
+++ b/app/models/discussion_entry.rb
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License along
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-
+require 'timeout'
 require 'atom'
 
 class DiscussionEntry < ActiveRecord::Base
@@ -347,7 +347,7 @@ class DiscussionEntry < ActiveRecord::Base
 
   def context_module_action
     if self.discussion_topic && self.user
-      self.discussion_topic.context_module_action(user, :contributed)
+      Timeout.timeout(7.minutes.to_i, Timeout::Error) { self.discussion_topic.context_module_action(user, :contributed) }
     end
   end
 

--- a/app/models/quizzes/quiz.rb
+++ b/app/models/quizzes/quiz.rb
@@ -841,11 +841,6 @@ class Quizzes::Quiz < ActiveRecord::Base
   def changed_significantly_since?(version_number)
     @significant_version ||= {}
     return @significant_version[version_number] if @significant_version.has_key?(version_number)
-    begin
-      old_version = self.versions.get(version_number).model
-    rescue NoMethodError
-      return false
-    end
 
     needs_review = false
     # Allow for floating point rounding error comparing to versions created before BigDecimal was used

--- a/app/models/quizzes/quiz.rb
+++ b/app/models/quizzes/quiz.rb
@@ -841,6 +841,7 @@ class Quizzes::Quiz < ActiveRecord::Base
   def changed_significantly_since?(version_number)
     @significant_version ||= {}
     return @significant_version[version_number] if @significant_version.has_key?(version_number)
+    old_version = self.versions.get(version_number).model
 
     needs_review = false
     # Allow for floating point rounding error comparing to versions created before BigDecimal was used

--- a/app/models/quizzes/quiz.rb
+++ b/app/models/quizzes/quiz.rb
@@ -841,7 +841,11 @@ class Quizzes::Quiz < ActiveRecord::Base
   def changed_significantly_since?(version_number)
     @significant_version ||= {}
     return @significant_version[version_number] if @significant_version.has_key?(version_number)
-    old_version = self.versions.get(version_number).model
+    begin
+      old_version = self.versions.get(version_number).model
+    rescue NoMethodError
+      return false
+    end
 
     needs_review = false
     # Allow for floating point rounding error comparing to versions created before BigDecimal was used

--- a/config/delayed_jobs.yml
+++ b/config/delayed_jobs.yml
@@ -4,6 +4,7 @@ development:
     workers: 1
 
 production:
+  work_queue: parent_process
   workers:
   - queue: canvas_queue
     workers: 2

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -25,7 +25,7 @@ Delayed::Backend::Base.class_eval do
   end
 end
 
-Delayed::Settings.max_attempts              = 15
+Delayed::Settings.max_attempts              = 5
 Delayed::Settings.queue                     = "canvas_queue"
 Delayed::Settings.sleep_delay               = ->{ Setting.get('delayed_jobs_sleep_delay', '2.0').to_f }
 Delayed::Settings.sleep_delay_stagger       = ->{ Setting.get('delayed_jobs_sleep_delay_stagger', '2.0').to_f }

--- a/config/initializers/launch_darkly.rb
+++ b/config/initializers/launch_darkly.rb
@@ -1,1 +1,7 @@
-Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new(ENV['LAUNCH_DARKLY_SDK_KEY'])
+opts = {}
+opts[:capacity] = 15000
+opts[:flush_interval] = 60
+opts[:diagnostic_opt_out] = true
+config = LaunchDarkly::Config.new(opts)
+
+Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new(ENV['LAUNCH_DARKLY_SDK_KEY'], config)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -50,5 +50,10 @@ plugin :tmp_restart
 pidfile './tmp/puma.pid'
 
 on_worker_boot do
-  Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new(ENV['LAUNCH_DARKLY_SDK_KEY'])
+  opts = {}
+  opts[:capacity] = 15000
+  opts[:flush_interval] = 60
+  opts[:diagnostic_opt_out] = true
+  config = LaunchDarkly::Config.new(opts)
+  Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new(ENV['LAUNCH_DARKLY_SDK_KEY'], config)
 end

--- a/lib/turnitin/outcome_response_processor.rb
+++ b/lib/turnitin/outcome_response_processor.rb
@@ -19,7 +19,7 @@ module Turnitin
   class OutcomeResponseProcessor
 
     # this one goes to 14 (so that the last attempt is ~24hr after the first)
-    MAX_ATTEMPTS=14
+    MAX_ATTEMPTS=5
 
     def self.max_attempts
       MAX_ATTEMPTS


### PR DESCRIPTION
[QTY-1807](https://strongmind.atlassian.net/browse/QTY-1807)

## Purpose 
Schools experienced an outage beginning with PrimaveraHS where delayed jobs were failing to process and were backing up the queue. As a result, students were unable to progress through their courses. We found the cause of the problem to revolve largely around Launch Darkly, its configuration, and the process of it streaming data back to LD causing mutex locks in the database which in turn force workers to restart, orphaning delayed jobs. When large amounts of submissions were being processed, an `after_save` callback on submissions was causing repeated calls to LD, causing the issue. 

## Approach 
Add additional Launch Darkly configuration to decrease number and frequency of calls to service. Add safe operation in places that are affected by the deletion of versions data. 

## Testing
There's not a way to test this locally in an effective manner. After making the change, we deployed to multiple schools that were affected and observed fewer sentry errors and **much** faster processing of delayed jobs with far fewer failures to process. We removed all temporary fixes from the codebase and saw no further evidence the problem was persisting. 

[QTY-1807]: https://strongmind.atlassian.net/browse/QTY-1807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ