### PR TITLE
QTY-2067: Remove pipeline service calls when in development

### DIFF
--- a/config/initializers/shim_settings_service.rb
+++ b/config/initializers/shim_settings_service.rb
@@ -1,5 +1,5 @@
 SettingsService::AuthToken.authenticator = ::AccessToken
 
 if ENV['RAILS_ENV'] == 'development'
-  SettingsService.update_settings(id: 1, value: 'false', setting: 'disable_pipeline', object: 'school')
+  SettingsService.update_settings(id: 1, value: 'true', setting: 'disable_pipeline', object: 'school')
 end


### PR DESCRIPTION
[QTY-2067](https://strongmind.atlassian.net/browse/QTY-2067)

## Purpose 
When working in our development environment, we are receiving errors regarding making calls to the pipeline service. As we typically don't utilize the pipeline service in our dev environment, turning off the setting will alleviate this issue.

## Approach 
The logic was already partially implemented throughout Canvas. We just needed to complete it by changing the setting and utilize Rails cache to make the calls vs. calling the db.

## Testing
Create a course while watching your logs, the error should no longer appear. In addition, tested on newidsandbox and it is still working as expected.

[QTY-2067]: https://strongmind.atlassian.net/browse/QTY-2067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ