### PR TITLE
QTY-1617

### DIFF
--- a/app/coffeescripts/views/course_settings/RelockModulesDialog.coffee
+++ b/app/coffeescripts/views/course_settings/RelockModulesDialog.coffee
@@ -4,16 +4,16 @@ define [
   'jquery'
   'underscore'
   'compiled/views/DialogBaseView'
-  'jst/modules/RelockModulesDialog'
+  'jst/course_settings/RelockModulesDialog'
 ], (I18n, $, _, DialogBaseView, template) ->
 
   class RelockModulesDialog extends DialogBaseView
 
     template: template
 
-    renderIfNeeded: (data) ->
-      if data.relock_warning
-        @module_id = data.id
+    renderIfNeeded: () ->
+#      if data.relock_warning
+#        @module_id = data.id
         @render().show()
 
     dialogOptions: ->

--- a/app/coffeescripts/views/course_settings/RelockModulesDialog.coffee
+++ b/app/coffeescripts/views/course_settings/RelockModulesDialog.coffee
@@ -13,7 +13,7 @@ define [
 
     renderIfNeeded: () ->
 #      if data.relock_warning
-#        @module_id = data.id
+      if ENV.relock_warning == true
         @render().show()
 
     dialogOptions: ->
@@ -29,5 +29,5 @@ define [
       ]
 
     relock: =>
-      url = "/api/v1/courses/#{ENV.COURSE_ID}/modules/#{@module_id}/relock"
+      url = "/api/v1/courses/#{ENV.COURSE_ID}/relock"
       @dialog.disableWhileLoading $.ajaxJSON(url, 'PUT', {}, => @close())

--- a/app/coffeescripts/views/course_settings/RelockModulesDialog.coffee
+++ b/app/coffeescripts/views/course_settings/RelockModulesDialog.coffee
@@ -1,0 +1,33 @@
+
+define [
+  'i18n!modules'
+  'jquery'
+  'underscore'
+  'compiled/views/DialogBaseView'
+  'jst/modules/RelockModulesDialog'
+], (I18n, $, _, DialogBaseView, template) ->
+
+  class RelockModulesDialog extends DialogBaseView
+
+    template: template
+
+    renderIfNeeded: (data) ->
+      if data.relock_warning
+        @module_id = data.id
+        @render().show()
+
+    dialogOptions: ->
+      id: 'relock_modules_dialog'
+      title: I18n.t 'requirements_changed', 'Requirements Changed'
+      buttons: [
+        text: I18n.t 'relock_modules', 'Re-Lock Modules'
+        click: @relock
+      ,
+        text: I18n.t 'continue', 'Continue'
+        'class' : 'btn-primary'
+        click: @cancel
+      ]
+
+    relock: =>
+      url = "/api/v1/courses/#{ENV.COURSE_ID}/modules/#{@module_id}/relock"
+      @dialog.disableWhileLoading $.ajaxJSON(url, 'PUT', {}, => @close())

--- a/app/coffeescripts/views/course_settings/RelockModulesDialog.coffee
+++ b/app/coffeescripts/views/course_settings/RelockModulesDialog.coffee
@@ -12,7 +12,6 @@ define [
     template: template
 
     renderIfNeeded: () ->
-#      if data.relock_warning
       if ENV.relock_warning == true
         @render().show()
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3096,9 +3096,14 @@ class Course < ActiveRecord::Base
     @progressions[user.id] ||= ContextModuleProgressions::Finder.find_or_create_for_context_and_user(self, user)
   end
 
+  def relock_warning?
+    @relock_warning = true
+  end
+
   private
 
   def effective_due_dates
     @effective_due_dates ||= EffectiveDueDates.for_course(self)
   end
+
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3096,9 +3096,6 @@ class Course < ActiveRecord::Base
     @progressions[user.id] ||= ContextModuleProgressions::Finder.find_or_create_for_context_and_user(self, user)
   end
 
-  def relock_warning?
-    @relock_warning = true
-  end
 
   private
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3095,12 +3095,10 @@ class Course < ActiveRecord::Base
     @progressions ||= {}
     @progressions[user.id] ||= ContextModuleProgressions::Finder.find_or_create_for_context_and_user(self, user)
   end
-
-
+  
   private
 
   def effective_due_dates
     @effective_due_dates ||= EffectiveDueDates.for_course(self)
   end
-
 end

--- a/app/views/jst/course_settings/RelockModulesDialog.handlebars
+++ b/app/views/jst/course_settings/RelockModulesDialog.handlebars
@@ -1,0 +1,7 @@
+<p>{{#t}}
+  You have changed the threshold requirements for an active course.
+  There may be students who have already progressed to this module and to others that depend on it.
+{{/t}}</p>
+<p>{{#t}}
+  Would you like to let students continue in the course or do you want to re-lock these modules until the new thresholds are met?
+{{/t}}</p>

--- a/app/views/jst/courses/RelockModulesDialog.handlebars
+++ b/app/views/jst/courses/RelockModulesDialog.handlebars
@@ -1,0 +1,7 @@
+<p>{{#t}}
+  You have changed the progression requirements for an active course.
+  There may be students who have already progressed to this module and to others that depend on it.
+{{/t}}</p>
+<p>{{#t}}
+  Would you like to let students continue in the course or do you want to re-lock these modules until the new requirements are completed?
+{{/t}}</p>

--- a/app/views/jst/courses/RelockModulesDialog.handlebars
+++ b/app/views/jst/courses/RelockModulesDialog.handlebars
@@ -1,7 +1,0 @@
-<p>{{#t}}
-  You have changed the progression requirements for an active course.
-  There may be students who have already progressed to this module and to others that depend on it.
-{{/t}}</p>
-<p>{{#t}}
-  Would you like to let students continue in the course or do you want to re-lock these modules until the new requirements are completed?
-{{/t}}</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -935,6 +935,7 @@ CanvasRails::Application.routes.draw do
       get 'courses/:course_id/recent_students', action: :recent_students, as: 'course_recent_students'
       get 'courses/:course_id/users', action: :users, as: 'course_users'
       get 'courses/:course_id/collaborations', controller: :collaborations, action: :api_index, as: 'course_collaborations_index'
+      put 'courses/:course_id/relock', action: :relock
       delete 'courses/:course_id/collaborations/:id', controller: :collaborations, action: :destroy
 
       # this api endpoint has been removed, it was redundant with just courses#users

--- a/public/javascripts/course_settings.js
+++ b/public/javascripts/course_settings.js
@@ -38,6 +38,13 @@ import './vendor/jquery.scrollTo'
 import 'jqueryui/autocomplete'
 import 'jqueryui/sortable'
 import 'jqueryui/tabs'
+import RelockModulesDialog from 'compiled/views/course_settings/RelockModulesDialog'
+
+  window.onload = (event) => {
+    console.log("page is fully loaded");
+    var relock_modules_dialog = new RelockModulesDialog();
+    relock_modules_dialog.renderIfNeeded();
+  };
 
   var GradePublishing = {
     status: null,

--- a/public/javascripts/course_settings.js
+++ b/public/javascripts/course_settings.js
@@ -307,9 +307,6 @@ import RelockModulesDialog from 'compiled/views/course_settings/RelockModulesDia
       },
       success: function(data) {
         $('#course_reload_form').submit();
-        console.log(data);
-        console.log(data.course);
-        // $(this).loadingImage('remove');
       },
       error: function(data) {
         $(this).loadingImage('remove');

--- a/public/javascripts/course_settings.js
+++ b/public/javascripts/course_settings.js
@@ -40,11 +40,11 @@ import 'jqueryui/sortable'
 import 'jqueryui/tabs'
 import RelockModulesDialog from 'compiled/views/course_settings/RelockModulesDialog'
 
-  window.onload = (event) => {
-    console.log("page is fully loaded");
-    var relock_modules_dialog = new RelockModulesDialog();
-    relock_modules_dialog.renderIfNeeded();
-  };
+  // window.onload = (event) => {
+  //   console.log("page is fully loaded");
+  //   var relock_modules_dialog = new RelockModulesDialog();
+  //   relock_modules_dialog.renderIfNeeded();
+  // };
 
   var GradePublishing = {
     status: null,
@@ -134,6 +134,8 @@ import RelockModulesDialog from 'compiled/views/course_settings/RelockModulesDia
         initialTab = _.indexOf(_.pluck($tabBar.find('> ul a'), 'hash'), location.hash);
 
     $tabBar.tabs({cookie: {}, active: initialTab >= 0 ? initialTab : null}).show();
+    var relock_modules_dialog = new RelockModulesDialog();
+    relock_modules_dialog.renderIfNeeded();
 
     $add_section_form.formSubmit({
       required: ['course_section[name]'],
@@ -311,6 +313,9 @@ import RelockModulesDialog from 'compiled/views/course_settings/RelockModulesDia
       },
       success: function(data) {
         $('#course_reload_form').submit();
+        console.log(data);
+        console.log(data.course);
+        // $(this).loadingImage('remove');
       },
       error: function(data) {
         $(this).loadingImage('remove');

--- a/public/javascripts/course_settings.js
+++ b/public/javascripts/course_settings.js
@@ -40,12 +40,6 @@ import 'jqueryui/sortable'
 import 'jqueryui/tabs'
 import RelockModulesDialog from 'compiled/views/course_settings/RelockModulesDialog'
 
-  // window.onload = (event) => {
-  //   console.log("page is fully loaded");
-  //   var relock_modules_dialog = new RelockModulesDialog();
-  //   relock_modules_dialog.renderIfNeeded();
-  // };
-
   var GradePublishing = {
     status: null,
     checkup: function () {


### PR DESCRIPTION
[QTY-1617](https://strongmind.atlassian.net/browse/QTY-1617)

## Purpose 
When teachers change minimum threshold settings (at the course level) for assignment groups, they should have the option to relock modules for students who no longer meet the updated minimum threshold requirements. 

## Approach 
We created a template and view for our relock warning modal (RelockModulesDialog.handlebars & RelockModulesDialog.coffee) that renders after course settings are edited and after the page refreshes. The render function has a condition on it to make sure we only display the warning if threshold settings were changed.

If the teacher chooses to relock modules, it'll hit our new relock action at the course level. This action grabs all the modules for the course and relocks progressions on each one.

## Testing
We tested locally and in new-id-sandbox. We set up a scenario where assignments in a module need to be completed in sequential order. We set a minimum threshold on these assignments, completed the assignments as a test student, and graded the assignments so they are just above the minimum threshold. Then, we raised the threshold in course settings and chose to relock modules in our new warning dialog. We verified that the test student was forced to redo the assignments since they no longer met the new requirements.

## Screenshots/Video
This is the relock dialog that will display when course threshold settings are edited (after saving).
<img width="1715" alt="image" src="https://user-images.githubusercontent.com/87540376/217044722-4d8423ec-c51c-4b9f-aec8-106ed873d607.png">


[QTY-1617]: https://strongmind.atlassian.net/browse/QTY-1617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ