### PR TITLE
QTY-370: prevent sentry error from being raised when users#update gets hit with an invalid email

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -41,6 +41,13 @@ if settings.present?
       Folio::InvalidPage
       Turnitin::Errors::SubmissionNotScoredError
     }
+    config.before_send = lambda do |event, hint|
+      if event.exception&.instance_variable_get(:@values)&.first&.type == "ActiveRecord::RecordInvalid" && hint[:exception].message == "Validation failed: Email is invalid"
+        nil
+      else
+        event
+      end
+    end
   end
 
   Sentry.set_tags(settings.fetch(:tags, {}).merge(

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -57,3 +57,7 @@ on_worker_boot do
   config = LaunchDarkly::Config.new(opts)
   Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new(ENV['LAUNCH_DARKLY_SDK_KEY'], config)
 end
+
+if ENV['RACK_ENV'] == 'development'
+  worker_timeout 3600
+end


### PR DESCRIPTION
[QTY-370](https://strongmind.atlassian.net/browse/QTY-370)

## Purpose 
currently we are raising an exception error and sending to sentry every time users#update method gets hit with an invalid email via the API. We want to prevent these exceptions from going to sentry but continue to raise the error in the application.

## Approach 
added before_send in the sentry_config so that ActiveRecord::RecordInvalid exceptions that are raised for invalid emails will not be sent to sentry.

## Testing
Tested via PostMan and sent invalid emails to see that the sentry envelope did not go out but the exception was still raised and a 422 was returned.
