### PR TITLE
QTY-2256: Return empty array when no submissions will exist

### DIFF
--- a/app/controllers/submissions_api_controller.rb
+++ b/app/controllers/submissions_api_controller.rb
@@ -358,6 +358,10 @@ class SubmissionsApiController < ApplicationController
     else
       assignments = assignment_scope.to_a
     end
+    
+    unless assignments.present?
+      return render(json: [], status: :ok)
+    end
 
     assignment_visibilities = {}
     assignment_visibilities = AssignmentStudentVisibility.users_with_visibility_by_assignment(course_id: @context.id, user_id: student_ids, assignment_id: assignments.map(&:id))


### PR DESCRIPTION
[QTY-2256](https://strongmind.atlassian.net/browse/QTY-2256)

## Purpose 
@StrongMind/horseshoes were receiving an abundance of 500 errors as a result of hitting an endpoint in Enterprise Canvas. When making a request to `/courses/:course_id/students/submissions?...`, the resource was returning a 500 error for courses that did not have any assignments with `workflow_state: 'published'`. The purpose of this change is to provide a more appropriate response to these API requests rather simply breaking down. 

## Approach 
Added a check within the method to ensure that assignments are present. If assignments are not present, we return early and render json with an empty array (as is the case when they make an API call to a similar `Assignment` endpoint) and return a `200`, since the resource was found but no records could be returned. 

## Testing
This was tested locally and in new-id-sandbox. Some example steps to replicate the issue are: 
1. Create a course with assignments in a state other than published
2. Make an API call (via Postman or by using the appropriate URI in a browser), to `courses/:course_id/students/submissions?include[]=assignment&student_ids[]=valid_student_id` (a valid student ID must be used in the params or an unauthorized error will occur)
3. Ensure that the response is `200` with `[]` being returned 
4. Update the assignments to a `published` workflow state
5. Make the API call a second time and verify that a valid JSON structure is returned

[QTY-2256]: https://strongmind.atlassian.net/browse/QTY-2256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ