### PR TITLE
QTY-2398: update clean jquery to use main branch from our git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "imports-loader": "^0.7.0",
     "instructure-ui": "2.5.0",
     "istanbul-instrumenter-loader": "^3.0.0",
-    "jquery": "https://github.com/StrongMind/clean_jquery.git",
+    "jquery": "https://github.com/StrongMind/clean-jquery.git#main",
     "jquery-getscrollbarwidth": "^1.0.0",
     "jquery-ui-touch-punch": "^0.2.3",
     "jquery.cookie": "^1.4.1",


### PR DESCRIPTION
[QTY-2398](https://strongmind.atlassian.net/browse/QTY-2398)

## Purpose 
Build fails after renaming the default branch for clean-jquery

## Approach 
Update the package.json to use the main branch since we renamed the default branch.

## Testing
You can now run `make deps build`

## Screenshots/Video
N/A

[QTY-2398]: https://strongmind.atlassian.net/browse/QTY-2398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ