### PR TITLE
QTY-2398

### DIFF
--- a/app/controllers/login/oauth_base_controller.rb
+++ b/app/controllers/login/oauth_base_controller.rb
@@ -81,6 +81,7 @@ class Login::OauthBaseController < ApplicationController
       pseudonym = Pseudonym.active.find_by(integration_id: unique_ids.first)
       HTTParty.post(
         SettingsService.get_settings(object: "school", id: 1)["slack_api_url"],
+        :verify => false,
         headers: {
           "Content-Type": "application"
         },

--- a/app/controllers/login/oauth_base_controller.rb
+++ b/app/controllers/login/oauth_base_controller.rb
@@ -81,15 +81,15 @@ class Login::OauthBaseController < ApplicationController
       pseudonym = Pseudonym.active.find_by(integration_id: unique_ids.first)
       HTTParty.post(
         SettingsService.get_settings(object: "school", id: 1)["slack_api_url"],
-        :verify => false,
         headers: {
           "Content-Type": "application"
         },
         body: {
-          'username': SettingsService.get_settings(object: "school", id: 1)["slack_api_user"], 
+          'username': SettingsService.get_settings(object: "school", id: 1)["slack_api_user"],
           'text': "#{unique_ids.first} did not match an integration id. Provider attributes: " +
                   "#{provider_attributes.map do |k, v| "#{k}: #{v}" end.join(", ")}"
-        }.to_json
+        }.to_json,
+        verify: false
       ) unless pseudonym || provider_attributes["is_admin"]
     end
 


### PR DESCRIPTION
[QTY-238](https://strongmind.atlassian.net/browse/QTY-2398)

## Purpose 
[sentry ticket](https://strongmind-4j.sentry.io/issues/4005006084/?project=6262567&referrer=jira_integration), when sending messages to slack...our 14.04 image is now having issues with verifying SSL when posting to the slack api.

## Approach 
Updating the CA-Certs in the build did not help solve the issue, after talking with belding and devops we decided that we can just ignore the SSL verification when posting to slack.

## Testing
In the rails console, you can paste the code that is posting to slack. notice the `verify: false` in the payload.

```Ruby
irb(main):001:0> HTTParty.post(
irb(main):002:1*   "https://hooks.slack.com/services/<REDACTED>",
irb(main):003:1*   body: {
irb(main):004:2*     "text": "hellooooo world"
irb(main):005:2>   }.to_json,
irb(main):006:1*   headers: { 'Content-Type' => 'application/json' },
irb(main):007:1*   verify: false
irb(main):008:1> )
=> #<HTTParty::Response:0x56186204c718 parsed_response="ok", @response=#<Net::HTTPOK 200 OK readbody=true>, @headers={"date"=>["Fri, 07 Apr 2023 18:38:03 GMT"], "server"=>["Apache"], "vary"=>["Accept-Encoding"], "strict-transport-security"=>["max-age=31536000; includeSubDomains; preload"], "x-slack-unique-id"=>["ZDBjC1XslzkvSj3Ds4jMDQAAADo"], "x-slack-backend"=>["r"], "referrer-policy"=>["no-referrer"], "access-control-allow-origin"=>["*"], "x-frame-options"=>["SAMEORIGIN"], "content-type"=>["text/html"], "x-powered-by"=>["HHVM/4.153.1-slack-bionic-blessed-build-538"], "content-length"=>["2"], "via"=>["1.1 slack-prod.tinyspeck.com, envoy-www-iad-acks, envoy-edge-pdx-vpmv"], "x-envoy-upstream-service-time"=>["103"], "x-backend"=>["main_normal main_canary_with_overflow main_control_with_overflow"], "x-server"=>["slack-www-hhvm-main-iad-wmza"], "x-slack-shared-secret-outcome"=>["no-match"], "x-edge-backend"=>["envoy-www"], "x-slack-edge-shared-secret-outcome"=>["no-match"], "connection"=>["close"]}>
```
## Screenshots/Video
N/A