### PR TITLE
QTY-2681: Fix query to match instructures

### DIFF
--- a/app/models/pseudonym.rb
+++ b/app/models/pseudonym.rb
@@ -222,7 +222,7 @@ class Pseudonym < ActiveRecord::Base
     unless self.deleted?
       self.shard.activate do
         existing_pseudo = Pseudonym.active.by_unique_id(self.unique_id).where(:account_id => self.account_id,
-          :authentication_provider_id => self.authentication_provider_id).exists?
+          :authentication_provider_id => self.authentication_provider_id).where.not(id: self).exists?
         if existing_pseudo
           self.errors.add(:unique_id, :taken,
             message: t("ID already in use for this account and authentication provider"))


### PR DESCRIPTION
[QTY-2601](https://strongmind.atlassian.net/browse/QTY-2601)

## Purpose 
In Enterprise Canvas, we were seeing an exception that was preventing users from being able to update login information (login ID, SIS ID, integration ID) from the UI. The application was preventing update due to a failing uniqueness validation. 

## Approach 
A previous [PR](https://github.com/StrongMind/canvas-lms/pull/493) updated a check for uniqueness of the integration ID due to another exception being raised in Sentry. The previous PR used the current Instructure query to fix the issue, however, a key piece of the query was missed during the implementation. 

In the previous fix, we moved away from looking from the `first` active `Pseudonym` record for a `unique_id` for a user:

#### Old
```
existing_pseudo = Pseudonym.active.by_unique_id(self.unique_id).where(:account_id => self.account_id,
          :authentication_provider_id => self.authentication_provider_id).first
```

To checking for the existence of any record: 

#### New
```
existing_pseudo = Pseudonym.active.by_unique_id(self.unique_id).where(:account_id => self.account_id,
          :authentication_provider_id => self.authentication_provider_id).exists?
```

The old code subsequently checked to make sure that the record returned wasn't the Pseudonym that was attempting to update (i.e. the record didn't prevent itself from updating by saying it wasn't unique):

#### Old
```
if existing_pseudo && existing_pseudo.id != self.id
```

When the check was removed, the corresponding check should have been added to the new query: 

#### New
```
.where.not(id: self).exists?
```

but was missed. 

This change simply adds this check to the query so the Pseudonym record doesn't prevent itself from updating. 
 

## Testing
- Navigate to the `Users` index of Enterprise Canvas
- Choose a test user to edit
- Change part of the login info
- Ensure that the update saves successfully

## Screenshots/Video
n/a - error message no longer appears but successful flash message offers little in the way of verification



[QTY-2601]: https://strongmind.atlassian.net/browse/QTY-2601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ