### PR TITLE
QTY-2879: create enrollment_state if missing

### DIFF
--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -711,9 +711,7 @@ class Enrollment < ActiveRecord::Base
     raise "cannot call enrollment_state on a new record" if new_record?
     state = self.association(:enrollment_state).target ||=
       self.shard.activate { EnrollmentState.where(:enrollment_id => self).first }
-    if state.nil?
-      state = create_enrollment_state
-    end
+    state ||= create_enrollment_state
     state.association(:enrollment).target ||= self # ensure reverse association
     state
   end

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -711,6 +711,9 @@ class Enrollment < ActiveRecord::Base
     raise "cannot call enrollment_state on a new record" if new_record?
     state = self.association(:enrollment_state).target ||=
       self.shard.activate { EnrollmentState.where(:enrollment_id => self).first }
+    if state.nil?
+      state = create_enrollment_state
+    end
     state.association(:enrollment).target ||= self # ensure reverse association
     state
   end


### PR DESCRIPTION
[QTY-2879](https://strongmind.atlassian.net/browse/QTY-2879)

## Purpose 
During this [outage](https://flipswitch.slack.com/archives/C056MPTAJ7J), it was found that specific enrollments were missing enrollment states. For whatever reason they were either destroyed or never created, preventing the users settings page from loading correctly

## Approach 
when the enrollment state is invoked off the model, we now create the enrollment_state if it doesn't exist for the current enrollment.

## Testing
You can destroy an EnrollmentState tied to existing enrollment and see that it'll get recreated.

## Screenshots/Video
N/A

[QTY-2879]: https://strongmind.atlassian.net/browse/QTY-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ