### PR TITLE
PLT-6458: Create option for primary teacher filtering on messages

### DIFF
--- a/lib/messageable_user/calculator.rb
+++ b/lib/messageable_user/calculator.rb
@@ -539,7 +539,9 @@ class MessageableUser
       state_clauses.compact!
       return nil if state_clauses.empty?
 
-      "(#{state_clauses.join(' OR ')}) AND enrollments.type != 'StudentViewEnrollment'" << primary_teacher_enrollment_conditions
+      teacher_message_conditions = "(#{state_clauses.join(' OR ')}) AND enrollments.type != 'StudentViewEnrollment'"
+      teacher_message_conditions << primary_teacher_enrollment_conditions if options[:primary_teacher_only]
+      teacher_message_conditions
     end
 
     def self.primary_teacher_enrollment_conditions()
@@ -573,7 +575,8 @@ class MessageableUser
     def enrollment_scope(options={})
       options = {
         :common_course_column => 'enrollments.course_id',
-        :common_role_column => 'enrollments.type'
+        :common_role_column => 'enrollments.type',
+        :primary_teacher_only => true
       }.merge(options)
       scope = base_scope(options)
       scope = scope.joins("INNER JOIN #{Enrollment.quoted_table_name} ON enrollments.user_id=users.id")


### PR DESCRIPTION
[PLT-6458](https://strongmind.atlassian.net/browse/PLT-6458)

## Purpose 
In reference to this [bug](https://strongmind-4j.sentry.io/issues/4321995983/?project=6262567), adding this option will facilitate more granular control over messaging constraints for enrollment types. This removes unintended behavior by leaving default messaging scopes alone.

## Approach 
Create the attribute within the options and apply the conditional logic to our query to dictate whether or not to include it in the enrollment scope. 

## Testing
- Ensured that our previous changes are continuing to work as expected. 
- Verified that group messaging continues to work as expected.

[PLT-6458]: https://strongmind.atlassian.net/browse/PLT-6458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ