### PR TITLE
(B) QTY-1249: fix typo, return :bad_request vs :bad_reqquest in

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -285,11 +285,11 @@ class ConversationsController < ApplicationController
         :ACCOUNT_CONTEXT_CODE => "account_#{@domain_root_account.id}",
         :CAN_MESSAGE_ACCOUNT_CONTEXT => valid_account_context?(@domain_root_account),
         :MAX_GROUP_CONVERSATION_SIZE => Conversation.max_group_conversation_size,
-      } 
-      
-     
+      }
+
+
       is_admin = @current_user.roles(Account.site_admin).include? 'admin'
-        
+
       hash[:CAN_DELETE_INBOX_MESSAGES] = is_admin || @current_user.enrollments.active.any? { |e| e.has_permission_to?(:delete_inbox_messages) }
 
       notes_enabled_accounts = @current_user.associated_accounts.where(enable_user_notes: true)
@@ -297,7 +297,7 @@ class ConversationsController < ApplicationController
       hash[:NOTES_ENABLED] = notes_enabled_accounts.any?
       hash[:CAN_ADD_NOTES_FOR_ACCOUNT] = notes_enabled_accounts.any? {|a| a.grants_right?(@current_user, :manage_students) }
 
-      if hash[:NOTES_ENABLED] && !hash[:CAN_ADD_NOTES_FOR_ACCOUNT] 
+      if hash[:NOTES_ENABLED] && !hash[:CAN_ADD_NOTES_FOR_ACCOUNT]
         course_note_permissions = {}
         @current_user.enrollments.active.of_instructor_type.preload(:course).each do |enrollment|
           course_note_permissions[enrollment.course_id] = true if enrollment.has_permission_to?(:manage_user_notes)
@@ -907,7 +907,7 @@ class ConversationsController < ApplicationController
         return render :json => [], :status => :accepted
       end
     else
-      render :json => {}, :status => :bad_reqquest
+      render :json => {}, :status => :bad_request
     end
   end
 


### PR DESCRIPTION
add_message

[QTY-1249](https://strongmind.atlassian.net/browse/QTY-1249)

## Purpose 
if the add_message endpoint is hit without a body, the code will try and return a :bad_request....which happened to be misspelled. this pr fixes the typo.

## Approach 
n/a

## Testing
once this is deployed to newidsandbox, we can attempt to hit this enpoint with no body. we should expect a 400.

## Screenshots/Video
n/a

[QTY-1249]: https://strongmind.atlassian.net/browse/QTY-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ