### PR TITLE
QTY-377 add more logging for grade_passback failures

### DIFF
--- a/app/controllers/lti_api_controller.rb
+++ b/app/controllers/lti_api_controller.rb
@@ -185,7 +185,7 @@ class LtiApiController < ApplicationController
 
   def check_outcome(outcome)
     if ['unsupported', 'failure'].include? outcome.code_major
-      opts = {type: :grade_passback, course: @course}
+      opts = {type: :grade_passback}
       error_info = Canvas::Errors::Info.new(request, @domain_root_account, @current_user, opts).to_h
       error_info[:extra][:xml] = @xml.to_s if @xml
       capture_outputs = Canvas::Errors.capture("Grade pass back #{outcome.code_major}", error_info)

--- a/app/controllers/lti_api_controller.rb
+++ b/app/controllers/lti_api_controller.rb
@@ -33,6 +33,7 @@ class LtiApiController < ApplicationController
     end
 
     @xml = Nokogiri::XML.parse(request.body)
+    puts "grade_passback triggered: body: #{request.body}"
 
     lti_response = check_outcome BasicLTI::BasicOutcomes.process_request(@tool, @xml)
     render :body => lti_response.to_xml, :content_type => 'application/xml'

--- a/app/controllers/lti_api_controller.rb
+++ b/app/controllers/lti_api_controller.rb
@@ -184,10 +184,12 @@ class LtiApiController < ApplicationController
 
   def check_outcome(outcome)
     if ['unsupported', 'failure'].include? outcome.code_major
-      opts = {type: :grade_passback}
+      opts = {type: :grade_passback, course: @course}
       error_info = Canvas::Errors::Info.new(request, @domain_root_account, @current_user, opts).to_h
       error_info[:extra][:xml] = @xml.to_s if @xml
       capture_outputs = Canvas::Errors.capture("Grade pass back #{outcome.code_major}", error_info)
+      puts "ERROR INFO for grade pass back: #{error_info}"
+      Sentry.capture("Grade pass back #{outcome.code_major}", error_info)
       outcome.description += "\n[EID_#{capture_outputs[:error_report]}]"
     end
 

--- a/lib/canvas/errors/info.rb
+++ b/lib/canvas/errors/info.rb
@@ -35,7 +35,6 @@ module Canvas
         @rci = opts.fetch(:request_context_id, RequestContextGenerator.request_id)
         @type = opts.fetch(:type, nil)
         @canvas_error_info = opts.fetch(:canvas_error_info, {})
-        @course = opts.fetch(:course, nil)
       end
 
       # The ideal hash format to pass to Canvas::Errors.capture().
@@ -48,8 +47,7 @@ module Canvas
             account_id: @account.try(:global_id),
             user_id: @user.try(:global_id),
             type: @type,
-            canvas_domain: ENV['CANVAS_DOMAIN'],
-            course: @course
+            canvas_domain: ENV['CANVAS_DOMAIN']
           },
           extra: {
             request_context_id: @rci,

--- a/lib/canvas/errors/info.rb
+++ b/lib/canvas/errors/info.rb
@@ -35,6 +35,7 @@ module Canvas
         @rci = opts.fetch(:request_context_id, RequestContextGenerator.request_id)
         @type = opts.fetch(:type, nil)
         @canvas_error_info = opts.fetch(:canvas_error_info, {})
+        @course = opts.fetch(:course, nil)
       end
 
       # The ideal hash format to pass to Canvas::Errors.capture().
@@ -47,7 +48,8 @@ module Canvas
             account_id: @account.try(:global_id),
             user_id: @user.try(:global_id),
             type: @type,
-            canvas_domain: ENV['CANVAS_DOMAIN']
+            canvas_domain: ENV['CANVAS_DOMAIN'],
+            course: @course
           },
           extra: {
             request_context_id: @rci,


### PR DESCRIPTION
[QTY-377](https://strongmind.atlassian.net/browse/QTY-377)

## Purpose 
Currently, when grade_passback fails, we only get info about the tool ID and domain. BY adding more logging, we're hoping to get more info about the assignment/course that is failing grade passback

## Approach 
Log more info about the request body that comes in on grade passback. Try `Sentry.Capture` in addition to the existing `Canvas::Errors.capture` to see if we get more info.

## Testing
Make sure app is up and running locally (since we just added logging, there should be no breaking changes)

## Screenshots/Video
N/A

[QTY-377]: https://strongmind.atlassian.net/browse/QTY-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ