### PR TITLE
QTY-4252 ensure module item id is set for new module items

### DIFF
--- a/public/javascripts/context_modules.js
+++ b/public/javascripts/context_modules.js
@@ -615,7 +615,7 @@ import 'compiled/jquery.rails_flash_notifications'
 
       addItemToModule: function($module, data) {
         if (!data) { return $('<div/>'); }
-        data.id = data.id || 'new'
+        data.id = data['item[id'] || 'new'
         data.type = data.type || data['item[type]'] || $.underscore(data.content_type);
         data.title = data.title || data['item[title]'];
         data.new_tab = data.new_tab ? '1' : '0';

--- a/public/javascripts/context_modules.js
+++ b/public/javascripts/context_modules.js
@@ -615,7 +615,7 @@ import 'compiled/jquery.rails_flash_notifications'
 
       addItemToModule: function($module, data) {
         if (!data) { return $('<div/>'); }
-        data.id = data['item[id'] || 'new'
+        data.id = data['item[id]'] || 'new'
         data.type = data.type || data['item[type]'] || $.underscore(data.content_type);
         data.title = data.title || data['item[title]'];
         data.new_tab = data.new_tab ? '1' : '0';

--- a/public/javascripts/context_modules.js
+++ b/public/javascripts/context_modules.js
@@ -615,7 +615,7 @@ import 'compiled/jquery.rails_flash_notifications'
 
       addItemToModule: function($module, data) {
         if (!data) { return $('<div/>'); }
-        data.id = data['item[id]'] || data.content_id || 'new'
+        data.id = data.id || data['item[id]'] || 'new'
         data.type = data.type || data['item[type]'] || $.underscore(data.content_type);
         data.title = data.title || data['item[title]'];
         data.new_tab = data.new_tab ? '1' : '0';

--- a/public/javascripts/context_modules.js
+++ b/public/javascripts/context_modules.js
@@ -615,7 +615,7 @@ import 'compiled/jquery.rails_flash_notifications'
 
       addItemToModule: function($module, data) {
         if (!data) { return $('<div/>'); }
-        data.id = data['item[id]'] || 'new'
+        data.id = data['item[id]'] || data.content_id || 'new'
         data.type = data.type || data['item[type]'] || $.underscore(data.content_type);
         data.title = data.title || data['item[title]'];
         data.new_tab = data.new_tab ? '1' : '0';


### PR DESCRIPTION
[QTY-4252](https://strongmind.atlassian.net/browse/QTY-4252)

## Purpose 
When a user creates a new module item, they should be able to click and view the item. Without this change, user will see a "page not found" error if they try to view the item right after creating it unless they refresh. With our change, page will load without the need to refresh.

## Approach 
The method `addItemToModule()` is called in several places. For new module items, this gets called twice. The first time it is called, the module item looks like this:

<img width="232" alt="image" src="https://github.com/StrongMind/canvas-lms/assets/87540376/a10ccab2-8489-4062-b1a2-cb680fdcae50">

The second time, the item looks like this:
<img width="244" alt="image" src="https://github.com/StrongMind/canvas-lms/assets/87540376/21619dec-8928-4098-82f0-b5c9348f3c8c">

The module item id gets set using data.id. We added a fallback value of `data["item[id]"]` to handle the case that the module comes through as the structure in the first image.

This gives us a valid URL to navigate to when the user clicks on the module without refreshing.

## Testing
Run the application locally and verify that user can click on a module item right after creating it and that it loads successfully without errors

## Screenshots/Video


[QTY-4252]: https://strongmind.atlassian.net/browse/QTY-4252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ