### PR TITLE
Revert "Bump tinymce from 4.5.7 to 5.10.8"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "sanitize.css": "^5.0.0",
     "strongmind-icons": "6.0.1",
     "styled-components": "^2.4.0",
-    "tinymce": "5.10.8"
+    "tinymce": "4.5.7"
   },
   "devDependencies": {
     "axe-core": "2.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8338,12 +8338,7 @@ tinymce-light-skin@1.3.1, tinymce-light-skin@~1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/tinymce-light-skin/-/tinymce-light-skin-1.3.1.tgz#fcce7a8b5761716a381f756e1ac7f47c7a41ea88"
 
-tinymce@5.10.8:
-  version "5.10.8"
-  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-5.10.8.tgz#c85758fa3cca2cbb4b14dd037a0b315b6462c50e"
-  integrity sha512-iyoo3VGMAJhLMDdblAefKvYgBRk9kQi58GTwAmoieqsyggGsKZWlQl/YY6nTILFHUCA1FhYu0HdmM5YYjs17UQ==
-
-tinymce@~4.5.7:
+tinymce@4.5.7, tinymce@~4.5.7:
   version "4.5.7"
   resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-4.5.7.tgz#e1f5cd286ec3c9977bd672a4c14e496f63bc4fef"
 


### PR DESCRIPTION
Reverts StrongMind/canvas-lms#527

canvas can't handle large bumps in dependencies like this.