### PR TITLE
Revert "Bump lodash from 2.4.1 to 4.17.21 in /client_apps/canvas_quizzes"

### DIFF
--- a/client_apps/canvas_quizzes/package.json
+++ b/client_apps/canvas_quizzes/package.json
@@ -64,7 +64,7 @@
     "glob": "7.0.5",
     "grunt": "0.4.5",
     "grunt-cli": "1.2.0",
-    "lodash": "4.17.21",
+    "lodash": "2.4.1",
     "requirejs": "~2.2.0",
     "react-tools": "0.11.2",
     "shelljs": "0.7.0"

--- a/client_apps/canvas_quizzes/yarn.lock
+++ b/client_apps/canvas_quizzes/yarn.lock
@@ -1288,29 +1288,25 @@ lodash@1.2.x:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.2.1.tgz#ed47b16e46f06b2b40309b68e9163c17e93ea304"
 
+lodash@2.4.1, lodash@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.1.tgz#5b7723034dda4d262e5a46fb2c58d7cc22f71420"
+
 lodash@3.7.x:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.7.0.tgz#3678bd8ab995057c07ade836ed2ef087da811d45"
 
-lodash@4.17.21, lodash@^4.0.0, lodash@x:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-
-lodash@^3.10.1:
+lodash@^3.10.1, lodash@x:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
+lodash@^4.0.0, lodash@~4.16.4:
+  version "4.16.6"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
 
 lodash@~0.9.0, lodash@~0.9.2:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-0.9.2.tgz#8f3499c5245d346d682e5b0d3b40767e09f1a92c"
-
-lodash@~2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.1.tgz#5b7723034dda4d262e5a46fb2c58d7cc22f71420"
-
-lodash@~4.16.4:
-  version "4.16.6"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
 
 lolex@1.3.2:
   version "1.3.2"


### PR DESCRIPTION
Reverts StrongMind/canvas-lms#530
