### PR TITLE
(B) QTY-377: update grade_passback to return 422 in cases where we can't process the payload

### DIFF
--- a/app/controllers/lti_api_controller.rb
+++ b/app/controllers/lti_api_controller.rb
@@ -35,8 +35,8 @@ class LtiApiController < ApplicationController
     @xml = Nokogiri::XML.parse(request.body)
     puts "grade_passback triggered: body: #{request.body}"
 
-    lti_response = check_outcome BasicLTI::BasicOutcomes.process_request(@tool, @xml)
-    render :body => lti_response.to_xml, :content_type => 'application/xml'
+    lti_response, status = check_outcome BasicLTI::BasicOutcomes.process_request(@tool, @xml)
+    render :body => lti_response.to_xml, :content_type => 'application/xml', :status => status
   end
 
   # this similar API implements the older work-in-process BLTI 0.0.4 outcome
@@ -45,8 +45,8 @@ class LtiApiController < ApplicationController
   def legacy_grade_passback
     verify_oauth
 
-    lti_response = check_outcome BasicLTI::BasicOutcomes.process_legacy_request(@tool, params)
-    render :body => lti_response.to_xml, :content_type => 'application/xml'
+    lti_response, status = check_outcome BasicLTI::BasicOutcomes.process_legacy_request(@tool, params)
+    render :body => lti_response.to_xml, :content_type => 'application/xml', :status => status
   end
 
   # examples: https://github.com/adlnet/xAPI-Spec/blob/master/xAPI.md#AppendixA
@@ -184,17 +184,20 @@ class LtiApiController < ApplicationController
   end
 
   def check_outcome(outcome)
-    if ['unsupported', 'failure'].include? outcome.code_major
-      opts = {type: :grade_passback}
-      error_info = Canvas::Errors::Info.new(request, @domain_root_account, @current_user, opts).to_h
+    return outcome, 200 unless ["unsupported", "failure"].include? outcome.code_major
+
+    opts = { type: :grade_passback }
+    error_info = Canvas::Errors::Info.new(request, @domain_root_account, @current_user, opts).to_h
+    error_info[:extra][:description] = outcome.description
+    error_info[:extra][:message] = outcome.code_major
+
+    begin
       error_info[:extra][:xml] = @xml.to_s if @xml
-      error_info[:extra][:outcome] = outcome.to_h
-      capture_outputs = Canvas::Errors.capture("Grade pass back #{outcome.code_major}", error_info)
-      puts "ERROR INFO for grade pass back: #{error_info}"
-      Sentry.capture("Grade pass back #{outcome.code_major}", error_info)
+    rescue => e
       outcome.description += "\n[EID_#{capture_outputs[:error_report]}]"
     end
 
-    outcome
+    Sentry.capture("Grade pass back #{outcome.code_major}", error_info)
+    [outcome, 422]
   end
 end

--- a/app/controllers/lti_api_controller.rb
+++ b/app/controllers/lti_api_controller.rb
@@ -197,7 +197,6 @@ class LtiApiController < ApplicationController
       outcome.description += "\n[EID_#{capture_outputs[:error_report]}]"
     end
 
-    Sentry.capture("Grade pass back #{outcome.code_major}", error_info)
     [outcome, 422]
   end
 end

--- a/lib/basic_lti/basic_outcomes.rb
+++ b/lib/basic_lti/basic_outcomes.rb
@@ -96,15 +96,15 @@ module BasicLTI
       end
 
       def sourcedid
-        @lti_request.at_css('imsx_POXBody sourcedGUID > sourcedId').try(:content)
+        @lti_request&.at_css('imsx_POXBody sourcedGUID > sourcedId').try(:content)
       end
 
       def message_ref_identifier
-        @lti_request.at_css('imsx_POXHeader imsx_messageIdentifier').try(:content)
+        @lti_request&.at_css('imsx_POXHeader imsx_messageIdentifier').try(:content)
       end
 
       def operation_ref_identifier
-        tag = @lti_request.at_css('imsx_POXBody *:first').try(:name)
+        tag = @lti_request&.at_css('imsx_POXBody *:first').try(:name)
         tag && tag.sub(%r{Request$}, '')
       end
 


### PR DESCRIPTION
[QTY-377](https://strongmind.atlassian.net/browse/QTY-377)

## Purpose 
up until now, we've been returning 200s on grade_passback calls whether they were successful or not. this pr changes the behavior to now return a 422 if unprocessable. 

## Approach 
attempt to process the payload for grade passback, if success return 200. otherwise return 422 and include the reason for the failure

## Testing
deployed to newidsandbox
* run through a course using pointful cartridge, you can see grades get updated as you progress through the content
* postman - posted both a good payload & a bad payload

## Screenshots/Video
n/a

[QTY-377]: https://strongmind.atlassian.net/browse/QTY-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ