### PR TITLE
Turn off sentry tracing for now

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -29,7 +29,7 @@ if settings.present?
   Sentry.init do |config|
     config.dsn = settings[:dsn]
     config.breadcrumbs_logger = [:sentry_logger, :http_logger]
-    config.traces_sample_rate = 0.05
+    config.traces_sample_rate = 0
     config.capture_exception_frame_locals = true
     config.transport.ssl_verification = false
     config.release = Canvas.revision


### PR DESCRIPTION
## Purpose 
We are still blowing through our 100k transactions for the org in less than a day. Would like to try this out in Central, so we need to turn it off here.

## Approach 
Set sample rate to 0.
https://docs.sentry.io/platforms/ruby/performance/

