### PR TITLE
Qty 5525

### DIFF
--- a/lib/grade_calculator.rb
+++ b/lib/grade_calculator.rb
@@ -66,6 +66,12 @@ class GradeCalculator
         compute_score_opts.merge(grading_period: grading_period)
       ).compute_and_save_scores
     end
+
+    # publish student enrollment nouns when we're called by zero grader
+    # zero grader will call us with a single user_id
+    return if user_ids.length > 1
+    enrollment = StudentEnrollment.find_by(user_id: user_ids, course_id: course_id)
+    enrollment.publish_as_v2 if enrollment
   end
 
   def compute_scores


### PR DESCRIPTION
[QTY-5525](https://strongmind.atlassian.net/browse/QTY-5525)

## Purpose 
This pr modifies the GradeCalculator to send the `student_enrollment` noun to the data pipeline as soon as the grade calculation has finished. prior to this change, there is a high chance of sending stale grade info since the nouns were firing before the recalculate job was finished

## Approach 
extracted this from the shim and moved it up into this call since call
## Testing
This PR combined with changes in canvas-lms is deployed to new-id-sandbox, i've modified zero grader to run every 5 mins. I can see StudentEnrollment nouns firing with the correct grades now

## Screenshots/Video
<img width="1838" alt="image" src="https://github.com/StrongMind/canvas_shim/assets/88393833/e3919fa4-bc51-40fc-b3af-3fc29f62477f">
<img width="721" alt="image" src="https://github.com/StrongMind/canvas_shim/assets/88393833/ca6ac106-5fe5-441f-af0c-c68a17704272">
