### PR TITLE
Add AI Assistant widget, behind a feature flag.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2275,4 +2275,10 @@ class ApplicationController < ActionController::Base
                           }
   end
   before_action :launch_darkly_user, if: Proc.new { @current_user.present? }
+
+  def expose_ai_assistant?
+    return false if @launch_darkly_user.nil?
+    Rails.configuration.launch_darkly_client.variation("expose-ai-assistant", @launch_darkly_user, false)
+  end
+  helper_method :expose_ai_assistant?
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -76,6 +76,10 @@
 
   load_blueprint_courses_ui
 -%>
+<% if expose_ai_assistant? %>
+  <script src="https://cdn.tailwindcss.com/"></script>
+  <script src="https://central.strongmind.com/assistant/js" type="application/javascript"></script>
+<% end %>
 <%= render :partial => "layouts/head" %>
 <body class="<%= (@body_classes).uniq.join(' ') %> hide-interface">
 <%if @real_current_user && @real_current_user != @current_user %>
@@ -305,6 +309,9 @@
     <div class="NewUserTutorialTray__Container"></div>
   <% end %>
   <%= render :partial => 'layouts/foot', :locals => { :include_common_bundle => true } %>
+  <% if expose_ai_assistant? %>
+    <div id="sm-ai-assistant"></div>
+  <% end %>
 </div> <!-- #application -->
 <% if !Rails.env.development? && !Rails.env.test? %>
   <script>


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/HWTJ-2)

## Purpose 
So that a student can access AI help in a course, expose an AI Assistant widget, behind a feature flag

## Approach 
Use a launch darkly application helper method.

## Testing
Will test either with qwerty help, or in test env.