### PR TITLE
QTY-6483 speed grader vulnerability

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2278,7 +2278,9 @@ class ApplicationController < ActionController::Base
 
   def expose_ai_assistant?
     return false if @launch_darkly_user.nil?
-    Rails.configuration.launch_darkly_client.variation("expose-ai-assistant", @launch_darkly_user, false)
+    Rails.cache.fetch("expose-ai-assistant-#{@launch_darkly_user[:key]}", expires_in: 10.minutes) do
+      Rails.configuration.launch_darkly_client.variation("expose-ai-assistant", @launch_darkly_user, false)
+    end
   end
   helper_method :expose_ai_assistant?
 end

--- a/app/controllers/student_assignment_settings_controller.rb
+++ b/app/controllers/student_assignment_settings_controller.rb
@@ -2,7 +2,7 @@ class StudentAssignmentSettingsController < ApplicationController
   def update
     # {"value"=>"increment", "user_id"=>"1", "assignment_id"=>"2", "id"=>"max_attempts"}
     assignment = ::Assignment.find(params[:assignment_id])
-    return render_json_unauthorized unless authorized_action(assignment.course, @current_user, :manage_assignments)
+    reject!("Only teachers may add attempts", :forbidden) unless authorized_action(assignment.course, @current_user, :manage_assignments)
 
     SettingsService.update_settings(
       id: {

--- a/app/controllers/student_assignment_settings_controller.rb
+++ b/app/controllers/student_assignment_settings_controller.rb
@@ -1,6 +1,8 @@
 class StudentAssignmentSettingsController < ApplicationController
   def update
     # {"value"=>"increment", "user_id"=>"1", "assignment_id"=>"2", "id"=>"max_attempts"}
+    assignment = ::Assignment.find(params[:assignment_id])
+    return render_json_unauthorized unless authorized_action(assignment.course, @current_user, :manage_assignments)
 
     SettingsService.update_settings(
       id: {


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-6483)

## Purpose 
prevent students from posting to the max_attempts endpoint in order to add an additional attempt

## Approach 
reject with a 401 if user isn't doesn't have a role with `manage_assignments` permissions

## Testing
deployed to newidsandbox, we were able to reproduce the vulnerability before our change and after the change. after change user gets a 401 when done as student.

## Screenshots/Video
before
![image](https://github.com/StrongMind/canvas-lms/assets/88393833/7c57b1ae-d0da-4019-a057-2f7de2930a1e)


after
![image](https://github.com/StrongMind/canvas-lms/assets/88393833/bb1ad3b1-e710-4cc2-aff0-816e3f27c3f4)
