### PR TITLE
STK-7127 Add order by workflow_state in role_scope

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -894,6 +894,7 @@ class Account < ActiveRecord::Base
         role_scope = role_scope.where(:account_id => self.account_chain.map(&:id))
       end
 
+      role_scope = role_scope.order("workflow_state ASC") # active before inactive
       role_scope.first
     end
   end


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/STK-7127)

## Purpose 
<!-- what/why -->
When troubleshooting role issues, we encountered this case where an inactive role is retrieved by this code, rather than the active one that replaced it.

## Approach 
<!-- how -->
Order by workflow_state so we get the active one.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Ran this in console. See screenshot below.

## Screenshots/Video
<!-- show before/after of the change if possible -->
![image](https://github.com/StrongMind/canvas-lms/assets/3137263/b856c7bb-894b-4756-9b90-86c1516950ab)
