### PR TITLE
(B) QTY-6270: Set current version to nil if NoMethodError

### DIFF
--- a/app/controllers/wiki_pages_api_controller.rb
+++ b/app/controllers/wiki_pages_api_controller.rb
@@ -477,7 +477,14 @@ class WikiPagesApiController < ApplicationController
                         else
                           true
                         end
-      render :json => wiki_page_revision_json(revision, @current_user, session, include_content, @page.current_version)
+
+      begin
+        current_version = @page.current_version
+      rescue NoMethodError
+        current_version = nil
+      end
+
+      render :json => wiki_page_revision_json(revision, @current_user, session, include_content, current_version)
     end
   end
 


### PR DESCRIPTION
[QTY-6270](https://strongmind.atlassian.net/browse/QTY-6270)

## Purpose 
In cases where there were no revisions current_version was throwing an error, instead we should handle it as a nil

## Approach 
if current_version fails due to a NoMethodError, current_version is nil

## Testing
Managed to reproduce error on new-id-sandbox will confirm the fix worked when we are able to deploy to new-id-sandbox


[QTY-6270]: https://strongmind.atlassian.net/browse/QTY-6270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ