### PR TITLE
(B) QTY-6270: Use proper error handling when a page has no revisions

### DIFF
--- a/app/controllers/wiki_pages_api_controller.rb
+++ b/app/controllers/wiki_pages_api_controller.rb
@@ -483,7 +483,7 @@ class WikiPagesApiController < ApplicationController
         return and render :json => { :message => 'No revisions found' }, :status => :not_found
       end
 
-      render :json => wiki_page_revision_json(revision, @current_user, session, include_content, current_version)
+      render :json => wiki_page_revision_json(revision, @current_user, session, include_content, @page.current_version)
     end
   end
 

--- a/app/controllers/wiki_pages_api_controller.rb
+++ b/app/controllers/wiki_pages_api_controller.rb
@@ -478,10 +478,9 @@ class WikiPagesApiController < ApplicationController
                           true
                         end
 
-      begin
-        current_version = @page.current_version
-      rescue NoMethodError
-        current_version = nil
+
+      if @page.versions.empty?
+        return and render :json => { :message => 'No revisions found' }, :status => :not_found
       end
 
       render :json => wiki_page_revision_json(revision, @current_user, session, include_content, current_version)


### PR DESCRIPTION
[QTY-6270](https://strongmind.atlassian.net/browse/QTY-6270)

Purpose
Check if a page has versions otherwise throw 404 error when a revision is trying to be accessed

Approach
Use proper error handling

Testing
Managed to reproduce error on new-id-sandbox will confirm the fix worked when we are able to deploy to new-id-sandbox


[QTY-6270]: https://strongmind.atlassian.net/browse/QTY-6270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ