### PR TITLE
(B) QTY-4756: Sanitize html styles on quiz and discussion questions

### DIFF
--- a/app/models/quizzes/quiz_submission.rb
+++ b/app/models/quizzes/quiz_submission.rb
@@ -300,6 +300,13 @@ class Quizzes::QuizSubmission < ActiveRecord::Base
         submission_data[previously_read_marker]
       end
     end
+
+    params.each do |param, _|
+      question_being_answered = /\Aquestion_(?<question_id>\d+)/.match(param)
+      next unless question_being_answered
+
+      params[param] = params[param].gsub(/(position|z-index|left|right|top|bottom|width|height):\s*[^;]+;/, '')
+    end
     params
   end
 

--- a/lib/api/html/content.rb
+++ b/lib/api/html/content.rb
@@ -23,6 +23,7 @@ module Api
     class Content
       def self.process_incoming(html, host: nil, port: nil)
         return html unless html.present?
+        html = sanitize_styles(html)
         content = self.new(html, host: host, port: port)
         # shortcut html documents that definitely don't have anything we're interested in
         return html unless content.might_need_modification?
@@ -134,6 +135,10 @@ module Api
       private
 
       APPLICABLE_ATTRS = %w{href src}.freeze
+
+      def self.sanitize_styles(html)
+        html.gsub(/(position|z-index|left|right|top|bottom|width|height):\s*[^;]+;/, '')
+      end
 
       def scrub_links!(node)
         APPLICABLE_ATTRS.each do |attr|


### PR DESCRIPTION
[QTY-4526](https://strongmind.atlassian.net/browse/QTY-4526)

## Purpose 
Sanitize styles that can cover up the applications screen blocking users from using the app

## Approach 
Sanitize styles using regex

## Testing
Local testing on canvas VM

## Screenshots/Video

https://github.com/StrongMind/canvas-lms/assets/121902867/757f9b2e-266a-45ca-a9dc-b2d77c0bca06




[QTY-4526]: https://strongmind.atlassian.net/browse/QTY-4526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ