### PR TITLE
(B) QTY-4245: Unique violation

### DIFF
--- a/app/models/stream_item.rb
+++ b/app/models/stream_item.rb
@@ -277,7 +277,7 @@ class StreamItem < ActiveRecord::Base
           end
         end
 
-        StreamItemInstance.unique_constraint_retry do
+        StreamItemInstance.unique_constraint_retry(retries: 3) do
           StreamItemInstance.where(:stream_item_id => stream_item_id, :user_id => sliced_user_ids).delete_all
           StreamItemInstance.bulk_insert(inserts)
         end

--- a/config/initializers/active_record.rb
+++ b/config/initializers/active_record.rb
@@ -586,6 +586,7 @@ class ActiveRecord::Base
         connection.clear_query_cache
         return result
       rescue ActiveRecord::RecordNotUnique
+        sleep 0.5
         next
       end
     end


### PR DESCRIPTION
[QTY-4245](https://strongmind.atlassian.net/browse/QTY-4245)

## Purpose 

Fixing a unique constraint issue

Related comment `config/initializers/active_record.rb#unique_constraint_retry` (line 577):
    # runs the block in a (possibly nested) transaction. if a unique constraint
    # violation occurs, it will run it "retries" more times. the nested
    # transaction (savepoint) ensures we don't mess up things for the outer
    # transaction. useful for possible race conditions where we don't want to
    # take a lock (e.g. when we create a submission).

Due to race conditions it seems they attempted to use retires, however they were only retrying once without any pause between retries

## Approach 
Increase retry count and wait slightly between retries to give race conditions more breathing room to finish

## Testing
Will need to wait and see if this bug resurfaces



[QTY-4245]: https://strongmind.atlassian.net/browse/QTY-4245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ