### PR TITLE
(B) QTY-7031: Properly capture a 404 error

### DIFF
--- a/app/controllers/context_modules_controller.rb
+++ b/app/controllers/context_modules_controller.rb
@@ -540,9 +540,15 @@ class ContextModulesController < ApplicationController
     @module = @context.context_modules.not_deleted.find(params[:context_module_id])
     if authorized_action(@module, @current_user, :update)
       @tag = @module.add_item(params[:item])
+
+      if @tag.nil?
+        return render :json => { message: 'Item not found' }, :status => :not_found
+      end
+
       unless @tag.valid?
         return render :json => @tag.errors, :status => :bad_request
       end
+
       json = @tag.as_json
       json['content_tag'].merge!(
         publishable: module_item_publishable?(@tag),


### PR DESCRIPTION
[QTY-7031](https://strongmind.atlassian.net/browse/QTY-7031)

## Purpose 
`@tag` will only be nil if no item is found in the `@module.add_item` method

## Approach 
Throw a 404 if tag is nil

## Testing
Tested on the canvas vm via teamviewer

## Screenshots/Video
![image](https://github.com/StrongMind/canvas-lms/assets/121902867/272b2361-2083-4f1a-8bb6-9d6bf74c7356)

