### PR TITLE
(B) QTY-6900: check for submission nils before attempting to update them

### DIFF
--- a/app/models/discussion_entry.rb
+++ b/app/models/discussion_entry.rb
@@ -198,10 +198,12 @@ class DiscussionEntry < ActiveRecord::Base
           submission.save!
         end
       else
-        submission.workflow_state = 'unsubmitted'
-        submission.submission_type = nil
-        submission.submitted_at = nil
-        submission.save!
+        unless submission.nil?
+          submission.workflow_state = 'unsubmitted'
+          submission.submission_type = nil
+          submission.submitted_at = nil
+          submission.save!
+        end
       end
     end
   end


### PR DESCRIPTION
[QTY-6900](https://strongmind.atlassian.net/browse/QTY-6900)

## Purpose 
to fix sentry [issue](https://strongmind-4j.sentry.io/issues/3466494521/events/70a4e211e48e4c2fae8857a9197ff08a/?project=6262567&referrer=next-event) undefined method `workflow_state=' for nil:NilClass


## Approach 
check for nils before trying to update submission records

## Testing
manually tested. Made sure there were no errors in Chrome dev console in the network tab and no errors in the server logs



[QTY-6900]: https://strongmind.atlassian.net/browse/QTY-6900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ