### PR TITLE
(B) QTY-6486: add character validation to conversation body

### DIFF
--- a/app/coffeescripts/views/conversations/MessageFormDialog.coffee
+++ b/app/coffeescripts/views/conversations/MessageFormDialog.coffee
@@ -281,6 +281,7 @@ define [
         required: ['body']
         property_validations:
           token_capture: => I18n.t("Invalid recipient name.") if @recipientView and !@recipientView.tokens.length
+          message_content: => I18n.t("Message content is too long.") if @$fullDialog.find(@$conversationBody).val().length > 65535
         handle_files: (attachments, data) ->
           data.attachment_ids = (a.attachment.id for a in attachments)
           data


### PR DESCRIPTION
[QTY-6486](https://strongmind.atlassian.net/browse/QTY-6486)

## Purpose 
To fix sentry [issue](https://strongmind-4j.sentry.io/issues/4978116410/?project=6262567&referrer=jira_integration) Validation failed: Body is too long (maximum is 65,535 characters)

## Approach 
add validation to coffeescript file that checks the length of the body on form submit

## Testing
manually tested by trying to submit a form above the character limit. 



[QTY-6486]: https://strongmind.atlassian.net/browse/QTY-6486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ