### PR TITLE
KAPE-3301 Stop clobbering bank titles when there is more than one question

### DIFF
--- a/app/models/importers/assessment_question_importer.rb
+++ b/app/models/importers/assessment_question_importer.rb
@@ -80,7 +80,7 @@ module Importers
           question_bank.migration_id = bank_mig_id
         elsif data['assessment_question_banks']
           if bank_hash = data['assessment_question_banks'].detect{|qb_hash| qb_hash['migration_id'] == question_bank.migration_id}
-            question_bank.title = bank_hash['title'] # we should update the title i guess?
+            question_bank.title = bank_hash["title"] if bank_hash["title"]
           end
         end
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/KAPE-3301)

## Purpose 
<!-- what/why -->
When importing QTIs built from learnosity's conversion tool, Canvas sets the bank title to "No Name - [course name]" if there is more than one item in the QTI file.

## Approach 
<!-- how -->
Only set the bank title to the title in the hash (that comes from inside certain types of QTI exported files) if it exists.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
RSpec, local testing

## Screenshots/Video
<!-- show before/after of the change if possible -->
Before
![image](https://github.com/StrongMind/canvas-lms/assets/3137263/ec13a052-5430-4725-a4dc-4037cba8d542)

After
![image](https://github.com/StrongMind/canvas-lms/assets/3137263/6d83c5b4-434a-48db-9f0d-601615883b22)
