### PR TITLE
QTY-6895: remove un-implemented routes to stop exceptions

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ CanvasRails::Application.routes.draw do
     resources(:settings, controller: :enrollment_settings)
   end
 
-  resources(:users) do
+  scope '/users/:user_id' do
     resources(:assignments) do
       resources(:settings, controller: :student_assignment_settings)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,14 +31,6 @@ CanvasRails::Application.routes.draw do
     resources(:settings, controller: :enrollment_settings)
   end
 
-  scope '/users/:user_id' do
-    resources(:assignments) do
-      resources(:settings, controller: :student_assignment_settings)
-    end
-
-    resources(:settings, controller: :user_settings)
-  end
-
   resources :submission_comments, only: [:update, :destroy]
 
   resources :epub_exports, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,14 @@ CanvasRails::Application.routes.draw do
     resources(:settings, controller: :enrollment_settings)
   end
 
+  scope '/users/:user_id' do
+    resources(:assignments) do
+      resources(:settings, controller: :student_assignment_settings)
+    end
+
+    resources(:settings, controller: :user_settings)
+  end
+
   resources :submission_comments, only: [:update, :destroy]
 
   resources :epub_exports, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -767,7 +767,7 @@ CanvasRails::Application.routes.draw do
   get 'search/bookmarks' => 'users#bookmark_search', as: :bookmark_search
   get 'search/rubrics' => 'search#rubrics'
   get 'search/all_courses' => 'search#all_courses'
-  resources :users, except: :destroy do
+  resources :users, except: [:destroy, :index] do
     match 'masquerade', via: [:get, :post]
     concerns :files, :file_images
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-6895)

## Purpose 
remove root `/users` path as it's not fully implemented and causes exceptions, instead we now get a 404.

## Approach 
remove the root resource, but keep the namespace.

## Testing
deployed to new-id-sandbox,  
* verified max attempts still works with this route
  * `/users/:user_id/assignments/:assignment_id/settings/max_attempts"` 

## Screenshots/Video
n/a