### PR TITLE
(B) QTY-7404:  Compact dictionary with nil values

### DIFF
--- a/app/models/quizzes/quiz_statistics/item_analysis/summary.rb
+++ b/app/models/quizzes/quiz_statistics/item_analysis/summary.rb
@@ -66,7 +66,7 @@ class Quizzes::QuizStatistics::ItemAnalysis::Summary
   def buckets
     @buckets ||= begin
                    bucket_defs = @options[:buckets]
-                   ranked_respondent_ids = @respondent_scores.sort_by(&:last)
+                   ranked_respondent_ids = @respondent_scores.compact.sort_by(&:last)
                    previous_floor = ranked_respondent_ids.length
                    buckets = {}
                    bucket_defs.each do |(name, cutoff)|


### PR DESCRIPTION
[QTY-7404](https://strongmind.atlassian.net/browse/QTY-7404)

## Purpose 
Solve ArgumentError comparison of NilClass with 3.0 failed 

## Approach 
Compact the dictionary to remove nil values

## Testing
Rails console to reproduce error and then fix it

## Screenshots/Video
![image](https://github.com/StrongMind/canvas-lms/assets/121902867/39d51143-bf42-4c8f-a351-530a13db03c2)



[QTY-7404]: https://strongmind.atlassian.net/browse/QTY-7404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ