### PR TITLE
(B) QTY-7414: Properly catch and send validation errors for user crea…

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2328,7 +2328,9 @@ class UsersController < ApplicationController
       @pseudonym = @context.pseudonyms.where(:sis_user_id => sis_user_id, :workflow_state => 'deleted').first
       if @pseudonym
         @pseudonym.workflow_state = 'active'
-        @pseudonym.save!
+        unless @pseudonym.save
+          return render(:json => {:errors => {:pseudonym => @pseudonym.errors}}, :status => 422)
+        end
         @user = @pseudonym.user
         @user.workflow_state = 'registered'
         @user.update_account_associations


### PR DESCRIPTION
[QTY-7414](https://strongmind.atlassian.net/browse/QTY-7414)

## Purpose 
Event Processor was generating exceptions when hitting this end point through an API. API's are expecting pure JSON responses, so the existing code prevented the processor from getting the full picture and sentry errors were generated.

## Approach 
Create a condition on failed pseudonym save that renders the error message as a json string, instead of raising an exception.

## Testing
Created a postman call that mimicked the payloads provided in the sentry issue. 
Matched data on local database where a single user has two pseudonyms, one in an active state, with some unique id and auth provider, and another in a deleted state with the same unique id and auth provider.
The postman call attempted to re-active the deleted pseudonym and generate the error.

## Screenshots/Video
**BEFORE CHANGE**
![image](https://github.com/StrongMind/canvas-lms/assets/91218050/79a1d052-10fd-45eb-9909-e42dc29383ea)

**AFTER CHANGE**
![image](https://github.com/StrongMind/canvas-lms/assets/91218050/d7148f86-e17f-47b6-b968-f4a33c4e811e)



[QTY-7414]: https://strongmind.atlassian.net/browse/QTY-7414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ