### PR TITLE
(B) QTY-6231: update teacher_due_date_for_display to return nil for all_due_dates if hash is empty

### DIFF
--- a/lib/dates_overridable.rb
+++ b/lib/dates_overridable.rb
@@ -201,7 +201,7 @@ module DatesOverridable
 
   def teacher_due_date_for_display(user)
     ao = overridden_for user
-    due_at || ao.due_at || all_due_dates.first[:due_at]
+    due_at || ao.due_at || (all_due_dates.first[:due_at] if all_due_dates.any?)
   end
 
   def formatted_dates_hash(dates)


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-6231)

## Purpose 
in response to this [sentry bug](https://strongmind-4j.sentry.io/issues/4916400007/?project=6262567&referrer=jira_integration). when the assignment is created, an email is trying to be sent out with info about the assignment, the problem is the assignment has no due date. the code is raising an exception on `all_due_dates.first[:due_at]`

## Approach 
update `teacher_due_date_for_display` to return nil in the case we hit `all_due_dates`  and the assignment has no due date.

## Testing
n/a

## Screenshots/Video
n/a