### PR TITLE
(B) QTY-7601: Conditionally render button to only appear to users tha…

### DIFF
--- a/app/controllers/quizzes/quiz_submissions_controller.rb
+++ b/app/controllers/quizzes/quiz_submissions_controller.rb
@@ -30,8 +30,6 @@ class Quizzes::QuizSubmissionsController < ApplicationController
   def index
     if params[:zip] && authorized_action(@quiz, @current_user, :grade)
       generate_submission_zip(@quiz, @context)
-    else
-      redirect_to named_context_url(@context, :context_quiz_url, @quiz.id)
     end
   end
 

--- a/app/controllers/quizzes/quizzes_controller.rb
+++ b/app/controllers/quizzes/quizzes_controller.rb
@@ -159,6 +159,7 @@ class Quizzes::QuizzesController < ApplicationController
   end
 
   def show
+    @user_authorized = @quiz.grants_any_right?(@current_user, session, *Array(:grade))
     if @quiz.deleted?
       flash[:error] = t('errors.quiz_deleted', "That quiz has been deleted")
       redirect_to named_context_url(@context, :context_quizzes_url)

--- a/app/views/quizzes/quizzes/_download_file_upload_submissions.html.erb
+++ b/app/views/quizzes/quizzes/_download_file_upload_submissions.html.erb
@@ -16,7 +16,7 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 %>
 
-<% if @quiz.has_file_upload_question? %>
+<% if @quiz.has_file_upload_question? && @user_authorized %>
   <%= render :partial => 'submissions/submission_download' %>
   <a href="<%= context_url(@context, :context_quiz_quiz_submissions_url, @quiz.id, :zip => 1) %>"
     id="download_submission_button"


### PR DESCRIPTION
[QTY-7601](https://strongmind.atlassian.net/browse/QTY-7601)

## Purpose 
To avoid double render sentry [errors](https://strongmind-4j.sentry.io/issues/5294207031/events/d31d01fae5314e709486fb92bc7aef26/?project=6262567&referrer=next-event)

## Approach 
conditionally render button only when the user is authorized to download submissions.
remove else statement that was creating the double redirect error and served no purpose.

Attempted to only change controller so that it would just render an error but the controller would continuously re render the error and no re-directs would happen due to being in a different controller

## Testing
manually tested by creating a user that had permissions 1:1 to a Department Chair role in primavera.strongmind.com and then trying to download submissions

## Screenshots/Video
n/a


[QTY-7601]: https://strongmind.atlassian.net/browse/QTY-7601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ