### PR TITLE
(B) QTY-7601: return error when user is undefined when uploading avatar

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -646,6 +646,7 @@ class FilesController < ApplicationController
 
   def create_pending
     @context = Context.find_by_asset_string(params[:attachment][:context_code])
+    return render json: "User was undefined, refresh and try again.", status: :unprocessable_entity if @context.nil?
     @asset = Context.find_asset_by_asset_string(params[:attachment][:asset_string], @context) if params[:attachment][:asset_string]
     @check_quota = true
     permission_object = nil


### PR DESCRIPTION
[QTY-7601](https://strongmind.atlassian.net/browse/QTY-7601)

## Purpose 
to fix bug from [this](https://strongmind-4j.sentry.io/issues/3376162941/events/b96728761454453d925467de333a4222/?project=6262567&referrer=next-event) sentry issue

## Approach 
manually handle error if the context is nil due to no context code, which would be derived from a user id.

## Testing
manually tested in local env




[QTY-7601]: https://strongmind.atlassian.net/browse/QTY-7601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ