### PR TITLE
(B) QTY-5077: Log Error instead of Raising When Navigating to Unsupported Module Items

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1561,7 +1561,7 @@ class ApplicationController < ActionController::Base
       end
     else
       flash[:error] = t "#application.errors.invalid_tag_type", "Didn't recognize the item type for this tag"
-      raise([tag, params].inspect)
+      Rails.logger.error "Unrecognized tag type: #{tag.content_type}. Tag: #{tag.inspect}. Params: #{params.inspect}"
       redirect_to named_context_url(context, error_redirect_symbol)
     end
   end


### PR DESCRIPTION
[QTY-5077](https://strongmind.atlassian.net/browse/QTY-5077)

## Purpose 
Users get unhelpful errors when attempting to navigate to unsupported module items, these are then raised as sentry errors.

## Approach 
Replace the existing raise with a logger, allowing users to see a more helpful error and creating logs of the event without raising to sentry.

## Testing
Recreated the event by navigating to a module item from a course, while triggering the else statement that shows the exception handling.

## Screenshots/Video
<img width="1110" alt="image" src="https://github.com/StrongMind/canvas-lms/assets/85210858/3c211687-e0a6-425b-885b-d2d8163da35d">



[QTY-5077]: https://strongmind.atlassian.net/browse/QTY-5077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ