### PR TITLE
(B) QTY-7635: Catch invalid uri error and return a bad request

### DIFF
--- a/app/controllers/external_tools_controller.rb
+++ b/app/controllers/external_tools_controller.rb
@@ -134,7 +134,13 @@ class ExternalToolsController < ApplicationController
   end
 
   def retrieve
-    @tool = ContextExternalTool.find_external_tool(params[:url], @context)
+
+    begin
+      @tool = ContextExternalTool.find_external_tool(params[:url], @context)
+    rescue Addressable::URI::InvalidURIError
+      return render json: { error: 'Bad request' }, status: :bad_request
+    end
+
     if !@tool
       flash[:error] = t "#application.errors.invalid_external_tool", "Couldn't find valid settings for this link"
       redirect_to named_context_url(@context, :context_url)

--- a/app/models/context_external_tool.rb
+++ b/app/models/context_external_tool.rb
@@ -436,13 +436,7 @@ class ContextExternalTool < ActiveRecord::Base
     return "" if url.blank?
     url = url.gsub(/[[:space:]]/, '')
     url = "http://" + url unless url.match(/:\/\//)
-
-    begin
-      res = Addressable::URI.parse(url).normalize
-    rescue Addressable::URI::InvalidURIError
-      return render json: { error: 'Bad request' }, status: :bad_request
-    end
-
+    res = Addressable::URI.parse(url).normalize
     res.query = res.query.split(/&/).sort.join('&') if !res.query.blank?
     res.to_s
   end

--- a/app/models/context_external_tool.rb
+++ b/app/models/context_external_tool.rb
@@ -436,7 +436,13 @@ class ContextExternalTool < ActiveRecord::Base
     return "" if url.blank?
     url = url.gsub(/[[:space:]]/, '')
     url = "http://" + url unless url.match(/:\/\//)
-    res = Addressable::URI.parse(url).normalize
+
+    begin
+      res = Addressable::URI.parse(url).normalize
+    rescue Addressable::URI::InvalidURIError
+      return render json: { error: 'Bad request' }, status: :bad_request
+    end
+
     res.query = res.query.split(/&/).sort.join('&') if !res.query.blank?
     res.to_s
   end


### PR DESCRIPTION
[QTY-7635](https://strongmind.atlassian.net/browse/QTY-7635)

## Purpose 
Catch and throw a bad request error instead of erroring out

## Approach 
Begin rescue an InvalidURI error

## Testing
Tested on newidsandbox to reproduce the error, was not able to reproduce locally.. so will test again on newidsandbox to see if the issue is resolved


[QTY-7635]: https://strongmind.atlassian.net/browse/QTY-7635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ