### PR TITLE
(B) QTY-6867: only assign email if email string is not empty

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1764,7 +1764,7 @@ class UsersController < ApplicationController
       respond_to do |format|
         if @user.update_attributes(user_params)
           @user.avatar_state = (old_avatar_state == :locked ? old_avatar_state : 'approved') if admin_avatar_update
-          @user.email = new_email if update_email
+          @user.email = new_email if update_email && new_email.presence
           @user.save if admin_avatar_update || update_email
           session.delete(:require_terms)
           flash[:notice] = t('user_updated', 'User was successfully updated.')


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-6867)

## Purpose 
to fix [this](https://strongmind-4j.sentry.io/issues/3376253541/?project=6262567&referrer=jira_integration) sentry issue which was caused when a user's email was updated to be an empty string

## Approach 
change controller to only update the users email if the new_email param is not empty

## Testing
manually tested in a local env

## Screenshots/Video
n/a
