### PR TITLE
(B) QTY-7957: Return a 401 when getting token fails

### DIFF
--- a/app/controllers/login/oauth2_controller.rb
+++ b/app/controllers/login/oauth2_controller.rb
@@ -34,7 +34,13 @@ class Login::Oauth2Controller < Login::OauthBaseController
     unique_id = nil
     provider_attributes = {}
     return unless timeout_protection do
-      token = @aac.get_token(params[:code], oauth2_login_callback_url)
+
+      begin
+        token = @aac.get_token(params[:code], oauth2_login_callback_url)
+      rescue Oauth2::Error => e
+        return render_json_unauthorized
+      end
+
       unique_id = @aac.unique_id(token)
       provider_attributes = @aac.provider_attributes(token)
 

--- a/lib/canvas/core_ext/oauth2.rb
+++ b/lib/canvas/core_ext/oauth2.rb
@@ -27,9 +27,7 @@ module AcceptOpenIDConnectParamAsValidResponse
     else
       opts[:params] = params
     end
-    Rails.logger.warn "OAuth2 request: #{opts.inspect}"
     response = request(options[:token_method], token_url, opts)
-    Rails.logger.warn "OAuth2 response: #{response.inspect}"
     error = OAuth2::Error.new(response)
     # only change is on this line; Microsoft doesn't send back an access_token if you're doing a pure OpenID Connect auth
     fail(error) if options[:raise_errors] && !(response.parsed.is_a?(Hash) && (response.parsed['access_token'] || response.parsed['id_token']))


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/TEAM-NUMBER)

## Purpose 
Stop rails from blowing up on the backend and give back an error to the client

## Approach 
Return unauthorized request

## Testing
To test OAuth2 I need to test in an identity environment, so I will test in newidsandbox first.

