### PR TITLE
(B) QTY-7536: Safely access the response body

### DIFF
--- a/gems/turnitin_api/lib/turnitin_api/outcomes_response_transformer.rb
+++ b/gems/turnitin_api/lib/turnitin_api/outcomes_response_transformer.rb
@@ -36,20 +36,21 @@ module TurnitinApi
 
     # download original
     def original_submission
-      yield make_call(response.body["outcome_originalfile"]["launch_url"])
+      launch_url = response_body_accessor('outcome_originalfile', 'launch_url')
+      yield make_call(launch_url)
     end
 
     # store link to report
     def originality_report_url
-      response.body["outcome_originalityreport"]["launch_url"]
+      response_body_accessor('outcome_originalityreport', 'launch_url')
     end
 
     def originality_data
-      response.body['outcome_originalityreport'].select {|k, _| %w(breakdown numeric).include?(k)}
+      response_body_accessor('outcome_originalityreport')&.select { |k, _| %w(breakdown numeric).include?(k) }
     end
 
     def uploaded_at
-      response.body['meta']['date_uploaded']
+      response_body_accessor('meta', 'date_uploaded')
     end
 
     def scored?
@@ -81,5 +82,8 @@ module TurnitinApi
       connection.post url, params.merge(header.signed_attributes)
     end
 
+    def response_body_accessor(*keys)
+      response.body&.dig(*keys)
+    end
   end
 end


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-7536)

## Purpose 
[Here](https://strongmind.atlassian.net/browse/QTY-7536) is the link for the bug in Jira.



## Approach 
This is happening when we try to access properties on a non-existent key in the response body. Our guard clause is ultimately what is throwing this exception:

```rb
submission.submitted_at = turnitin_client.uploaded_at if turnitin_client.uploaded_at
```

Here uploaded_at is throwing the issue with the following code because meta is not present in this case:

```rb
response.body['meta']['date_uploaded']
```
I have created a method to always return nil in these cases in order for these methods to behave as expected.

## Testing
* Tried to write and run tests for this but it's like, impossible.
