### PR TITLE
(B) QTY-8126: add context_module_id to assignment json

### DIFF
--- a/app/coffeescripts/models/Assignment.coffee
+++ b/app/coffeescripts/models/Assignment.coffee
@@ -156,6 +156,8 @@ define [
 
     courseID: => @get('course_id')
 
+    contextTagID: => @get('context_tag_id')
+
     submissionTypes: (submissionTypes) =>
       return @_submissionTypes() unless arguments.length > 0
       @set 'submission_types', submissionTypes
@@ -328,6 +330,12 @@ define [
     htmlUrl: =>
       @get 'html_url'
 
+    moduleItemUrl: =>
+      if @get 'context_tag_id'
+       return "#{@get 'html_url'}?module_item_id=#{@get 'context_tag_id'}"
+      else
+       return @htmlUrl()
+
     htmlEditUrl: =>
       "#{@get 'html_url'}/edit"
 
@@ -421,7 +429,8 @@ define [
         'allDates', 'hasDueDate', 'hasPointsPossible', 'singleSectionDueDate',
         'moderatedGrading', 'postToSISEnabled', 'isOnlyVisibleToOverrides',
         'omitFromFinalGrade', 'is_quiz_assignment', 'isQuizLTIAssignment',
-        'secureParams', 'inClosedGradingPeriod', 'dueDateRequired', 'submissionTypesFrozen'
+        'secureParams', 'inClosedGradingPeriod', 'dueDateRequired', 'submissionTypesFrozen',
+        'contextTagID', "moduleItemUrl"
       ]
 
       hash =

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -293,6 +293,11 @@ class Assignment < ActiveRecord::Base
     grading_standard_id
   )
 
+  def context_tag_id
+    if context_module_tags
+      context_module_tags.first.id unless context_module_tags.first.nil?
+    end
+  end
   def external_tool?
     self.submission_types == 'external_tool'
   end

--- a/app/views/jst/assignments/AssignmentListItem.handlebars
+++ b/app/views/jst/assignments/AssignmentListItem.handlebars
@@ -15,7 +15,7 @@
       <i aria-hidden="true" class='icon-{{iconType}}'></i>
     </div>
     <div class="ig-info">
-      <a href="{{htmlUrl}}" class="ig-title">
+      <a href="{{moduleItemUrl}}" class="ig-title">
         {{name}}
         {{#if isExcused}}
           <span class="excused-assignment"></span>

--- a/lib/api/v1/assignment.rb
+++ b/lib/api/v1/assignment.rb
@@ -123,6 +123,7 @@ module Api::V1::Assignment
     hash['has_submitted_submissions'] = assignment.has_submitted_submissions?
     hash['due_date_required'] = assignment.due_date_required?
     hash['max_name_length'] = assignment.max_name_length
+    hash['context_tag_id'] = assignment.context_tag_id unless assignment.context_tag_id.nil?
 
     unless opts[:exclude_response_fields].include?('in_closed_grading_period')
       hash['in_closed_grading_period'] = assignment.in_closed_grading_period?


### PR DESCRIPTION


[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-8126)

## Purpose 
to fix an outage where a url would not have the context_module_id param which would cause issues when a student was doing a pre test

## Approach 
add context tag id to the assignment json paylaod so that it is available in the handlebar view so that the correct link could be built

## Testing
manually tested in a local env

## Screenshots/Video
<img width="625" alt="image" src="https://github.com/StrongMind/canvas-lms/assets/91218050/13180f82-8fc6-454f-a9d0-ea2892fca852">


