### PR TITLE
(B) QTY-8507: use users integration id off pseudonym if present for

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -326,7 +326,7 @@
       // Please use Strings, Numbers, or Bools for value types.
 
         let visitor = {
-            id:              '<%= lti_opaque_hash_for_current_user %>',
+            id:              '<%= @current_user.pseudonyms&.where.not(integration_id: nil).first&.integration_id || lti_opaque_hash_for_current_user %>',
             name:            '<%= @current_user.name if @current_user%>',
             email:           '<%= @current_user.email  if @current_user%>',
             school_name:     '<%= Account.find(1).name %>',


### PR DESCRIPTION
pendo, otherwise default to original behavior.

[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-8507)

## Purpose 
the pr introduces the idea of using the users integration id from pseudonym when initializing pendo, if the user doesn't have a pseudonym with an integration id....then we'll default to the original behavior

## Approach 
update the application.html.erb to use the users integration id if it exisits, otherwise use the original value.

## Testing
testing on newidsanbox

## Screenshots/Video
n/a