### PR TITLE
(B) QTY-8507: update pendo user id to be users integration id | other original behaviour

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -326,7 +326,7 @@
       // Please use Strings, Numbers, or Bools for value types.
 
         let visitor = {
-            id:              '<%= @current_user.pseudonyms&.where.not(integration_id: nil).first&.integration_id || lti_opaque_hash_for_current_user %>',
+            id:              '<%= ((@current_user.pseudonyms&.where.not(integration_id: nil).first&.integration_id) if @current_user) || lti_opaque_hash_for_current_user %>',
             name:            '<%= @current_user.name if @current_user%>',
             email:           '<%= @current_user.email  if @current_user%>',
             school_name:     '<%= Account.find(1).name %>',


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-8507)

## Purpose 
this PR resolves the issue where `@current_user` may not be set.

## Approach 
add a check for `@current_user`

## Testing
will check for integrations ids as users ids in pendo from enterprise canvas.

## Screenshots/Video
n/a
