### PR TITLE
QTY-9035: Adjust timezone when updating course from newidsandbox

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -2450,7 +2450,7 @@ class CoursesController < ApplicationController
       @course.send_later_if_production_enqueue_args(:touch_content_if_public_visibility_changed,
         { :priority => Delayed::LOW_PRIORITY }, changes)
       Rails.logger.info("Referrer: #{request.referer}")
-      course_saved = @course.errors.none? && (param[:update_timezone] ? @course.save_with_account_times : @course.save)
+      course_saved = @course.errors.none? && (params[:update_timezone] ? @course.save_with_account_times : @course.save)
       if course_saved
         Auditors::Course.record_updated(@course, @current_user, changes, source: logging_source)
         @current_user.touch

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -2451,7 +2451,6 @@ class CoursesController < ApplicationController
         { :priority => Delayed::LOW_PRIORITY }, changes)
       Rails.logger.info("Referrer: #{request.referer}")
       if @course.errors.none? && @course.save
-        course.set_course_start_end_time_from_school.save if param[:update_timezone]
         @course.set_course_start_end_time_from_school.save if params[:update_timezone]
         Auditors::Course.record_updated(@course, @current_user, changes, source: logging_source)
         @current_user.touch

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -2449,9 +2449,10 @@ class CoursesController < ApplicationController
 
       @course.send_later_if_production_enqueue_args(:touch_content_if_public_visibility_changed,
         { :priority => Delayed::LOW_PRIORITY }, changes)
-      Rails.logger("Referrer: #{request.referer}")
+      Rails.logger.info("Referrer: #{request.referer}")
       if @course.errors.none? && @course.save
         course.set_course_start_end_time_from_school.save if param[:update_timezone]
+        @course.set_course_start_end_time_from_school.save if params[:update_timezone]
         Auditors::Course.record_updated(@course, @current_user, changes, source: logging_source)
         @current_user.touch
         if params[:update_default_pages]

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -2449,8 +2449,9 @@ class CoursesController < ApplicationController
 
       @course.send_later_if_production_enqueue_args(:touch_content_if_public_visibility_changed,
         { :priority => Delayed::LOW_PRIORITY }, changes)
-
+      Rails.logger("Referrer: #{request.referer}")
       if @course.errors.none? && @course.save
+        course.set_course_start_end_time_from_school.save if param[:update_timezone]
         Auditors::Course.record_updated(@course, @current_user, changes, source: logging_source)
         @current_user.touch
         if params[:update_default_pages]

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -2450,8 +2450,8 @@ class CoursesController < ApplicationController
       @course.send_later_if_production_enqueue_args(:touch_content_if_public_visibility_changed,
         { :priority => Delayed::LOW_PRIORITY }, changes)
       Rails.logger.info("Referrer: #{request.referer}")
-      if @course.errors.none? && @course.save
-        @course.set_course_start_end_time_from_school.save if params[:update_timezone]
+      course_saved = @course.errors.none? && (param[:update_timezone] ? @course.save_with_account_times : @course.save)
+      if course_saved
         Auditors::Course.record_updated(@course, @current_user, changes, source: logging_source)
         @current_user.touch
         if params[:update_default_pages]


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-9035)

## Purpose 
<!-- what/why -->
Course updates were causing course conclude dates to changes dates depending on their timezone.

## Approach 
<!-- how -->
Change behaviour of timezone changing updates to only fire on course creation and course update from the UI.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Create specs in the shim

## Screenshots/Video
<!-- show before/after of the change if possible -->
