### PR TITLE
BEL-3136 Publish queue age metrics

### DIFF
--- a/Gemfile.d/app.rb
+++ b/Gemfile.d/app.rb
@@ -49,6 +49,7 @@ gem 'folio-pagination', '0.0.12', require: 'folio/rails'
 gem 'addressable', '2.5.1', require: false
 gem "after_transaction_commit", '2.0.0'
 gem 'aws-sdk-core', '3.38.0', require: false
+gem 'aws-sdk-cloudwatch', '1.12.0', require: false
 gem "aws-sdk-kinesis", require: false
 gem "aws-sdk-s3", require: false
 gem "aws-sdk-sns", require: false

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -147,8 +147,7 @@ Delayed::Worker.lifecycle.before(:error) do |worker, job, exception|
 end
 
 Delayed::Worker.lifecycle.before(:loop) do |worker|
-  unless Rails.cache.exist?("loop_stats_has_run_within_1m")
-    Rails.cache.write("loop_stats_has_run_within_1m", true, expires_in: 1.minute)
+  Rails.cache.fetch("loop_stats_has_run_within_1m", expires_in: 1.minute) do
     # log the age in seconds of the oldest job
     age = ((Delayed::Job.where(attempts: 0)
                         .where('run_at <= ?', DateTime.now.utc)
@@ -160,5 +159,6 @@ Delayed::Worker.lifecycle.before(:loop) do |worker|
     }
 
     Rails.logger.info(jobs.to_json)
+    true
   end
 end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -148,12 +148,9 @@ end
 
 Delayed::Worker.lifecycle.before(:loop) do |worker|
   # log the age in seconds of the oldest job
-  age = (
-    (
-      Delayed::Job.where(attempts: 0)
+  age = ((Delayed::Job.where(attempts: 0)
                   .where('run_at <= ?', DateTime.now.utc)
-                  .minimum(:run_at).to_datetime || DateTime.now)
-    - DateTime.now).to_i
+                  .minimum(:run_at)&.to_datetime || DateTime.now) - DateTime.now).to_i
 
   jobs = {
     name: "inst_jobs loop stats",

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License along
 # with this program. If not, see <http://www.gnu.org/licenses/>.
+require "aws-sdk-cloudwatch"
 
 Delayed::Job.include(JobLiveEventsContext)
 

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -151,9 +151,9 @@ Delayed::Worker.lifecycle.before(:loop) do |worker|
   Rails.cache.fetch("loop_stats_has_run_within_1m", expires_in: 1.minute) do
 
     # log the age in seconds of the oldest job
-    age = ((Delayed::Job.where(attempts: 0)
+    age = (DateTime.now.utc - (Delayed::Job.where(attempts: 0)
                         .where('run_at <= ?', DateTime.now.utc)
-                        .minimum(:run_at)&.to_datetime || DateTime.now) - DateTime.now).to_i
+                        .minimum(:run_at)&.to_datetime || DateTime.now.utc)).to_i
 
     client = Aws::CloudWatch::Client.new(region: 'us-west-2')
     client.put_metric_data({


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3136)

## Purpose 
We intend to dynamically scale numbers of workers in order to both more quickly handle spikes in our queues and also to save money when we do not have outstanding jobs.  This will publish the metrics needed for this work.

## Approach 
Use the hooks in the inst-job initializer to publish queue age information to cloudwatch metrics.

## Testing
Tested in canvas-stage.
We also verified that the IAM users that run canvas have access to write to cloudwatch metrics.

## Screenshots/Video

<img width="1041" alt="Screenshot 2024-09-17 at 2 11 27 PM" src="https://github.com/user-attachments/assets/a56d06f7-68c9-4969-b547-42f4958389c1">
