### PR TITLE
QTY-6895 Prevent blowup when trying to determine #authorized_action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -553,6 +553,8 @@ class ApplicationController < ActionController::Base
   #   render
   # end
   def authorized_action(object, actor, rights)
+    render_unauthorized_action if object.nil?
+
     can_do = object.grants_any_right?(actor, session, *Array(rights))
     render_unauthorized_action unless can_do
     can_do


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-6895)

https://strongmind-4j.sentry.io/issues/3479720512/?project=6262567&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=3d&stream_index=3

## Purpose 
render unauth if object passed into authorized action is nil so that we don't blow up when trying to determine if the
 user is attempting to make an authorized action

## Approach 
add guard clause

