### PR TITLE
PLT-13600: Add logging for grade passback call

### DIFF
--- a/app/controllers/lti_api_controller.rb
+++ b/app/controllers/lti_api_controller.rb
@@ -26,6 +26,7 @@ class LtiApiController < ApplicationController
 
   # this API endpoint passes all the existing tests for the LTI v1.1 outcome service specification
   def grade_passback
+    start_time = Time.now
     verify_oauth
 
     if request.content_type != "application/xml"
@@ -33,9 +34,19 @@ class LtiApiController < ApplicationController
     end
 
     @xml = Nokogiri::XML.parse(request.body)
-    puts "grade_passback triggered: body: #{request.body}"
 
     lti_response, status = check_outcome BasicLTI::BasicOutcomes.process_request(@tool, @xml)
+    end_time = Time.now
+    log = {
+      method: "grade_passback",
+      start_time: start_time,
+      end_time: end_time,
+      duration: end_time - start_time,
+      status: status,
+      lti_response: lti_response.to_json,
+      request_body: request.body.string
+    }
+    puts log.to_json
     render :body => lti_response.to_xml, :content_type => 'application/xml', :status => status
   end
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/PLT-13600)

## Purpose 
<!-- what/why -->
To troubleshoot why POES takes 10 seconds on average to do this, we are hoping we can see some pattern in the types of students/courses that take 20-60+ seconds in POES

## Approach 
<!-- how -->
Use puts to log JSON so that cloudwatch can parse it easier.

