### PR TITLE
(B) QTY-8981: Return unauthorized if context is nil

### DIFF
--- a/app/controllers/content_exports_controller.rb
+++ b/app/controllers/content_exports_controller.rb
@@ -23,6 +23,8 @@ class ContentExportsController < ApplicationController
   def require_permission
     get_context
     @context ||= @current_user # if we're going through the dashboard
+    
+    return render_unauthorized_action if @context.nil?
     return render_unauthorized_action unless @context.grants_all_rights?(@current_user, :read, :read_as_admin)
   end
 


### PR DESCRIPTION
[QTY-8981](https://strongmind.atlassian.net/browse/QTY-8981)

## Purpose 
In some cases context was nil when getting to this line

## Approach 
If context is nil assume user is unauthorized



[QTY-8981]: https://strongmind.atlassian.net/browse/QTY-8981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ