### PR TITLE
QTY-7191: return 409 on conflicts for  user creation with an existing integration id exists for a specific user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2505,6 +2505,15 @@ class UsersController < ApplicationController
             created_by_id: 1
           ) if params[:sis_user_note].present?
         end
+      rescue ActiveRecord::RecordNotUnique => e
+        errors = {
+          :errors => {
+            :user => @user.errors.as_json[:errors],
+            :pseudonym => @pseudonym.errors.as_json[:errors],
+            :observee => {}
+          }
+        }
+        return render :json => errors, :status => :conflict
       rescue ActiveRecord::RecordInvalid => e
         errors = {
           :errors => {
@@ -2513,9 +2522,6 @@ class UsersController < ApplicationController
             :observee => {}
           }
         }
-        # Intent is to verify whether or not the user is actually getting saved
-        # when we send a 400.
-        puts ("User create attempted: @user.id: #{@user.inspect}")
         return render :json => errors, :status => :bad_request
       end
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-7191)

## Purpose 
we don't need to be raising exceptions when a user create is posted for a user who already exists for a specific identity id

## Approach 
catch the `index_pseudonyms_on_unique_id_and_account_id` and return a 409

## Testing
n/a

## Screenshots/Video
n/a