### PR TITLE
PLT-13623 Remove extra query

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -52,7 +52,7 @@ class Assignment < ActiveRecord::Base
   restrict_columns :content, [:title, :description]
   restrict_assignment_columns
 
-  has_many :submissions
+  has_many :submissions, -> { active }
   has_many :all_submissions, class_name: 'Submission', dependent: :destroy
   has_many :provisional_grades, :through => :submissions
   has_many :attachments, :as => :context, :inverse_of => :context, :dependent => :destroy

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -52,7 +52,7 @@ class Assignment < ActiveRecord::Base
   restrict_columns :content, [:title, :description]
   restrict_assignment_columns
 
-  has_many :submissions, -> { active.preload(:grading_period) }
+  has_many :submissions
   has_many :all_submissions, class_name: 'Submission', dependent: :destroy
   has_many :provisional_grades, :through => :submissions
   has_many :attachments, :as => :context, :inverse_of => :context, :dependent => :destroy


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/PLT-13623)

## Purpose 
<!-- what/why -->
None of our schools have grading periods. Running this preload is wasteful. Noticed when going over all our queries to try to improve performance.

## Approach 
<!-- how -->
Turn off preload of grading periods whenever we query for the submissions on an assignment.