### PR TITLE
QTY-6959: Try addressing long-standing deadlocks

### DIFF
--- a/app/models/enrollment/recent_activity.rb
+++ b/app/models/enrollment/recent_activity.rb
@@ -52,9 +52,12 @@ class Enrollment
     end
 
     def update_with(options)
-      result = all_enrollments_scope.update_all(options)
-      
-      all_enrollments_scope.ids.each do |id|
+      active_scope = all_enrollments_scope
+                       .where.not(:activity_state => 'deleted')
+
+      result = active_scope.update_all(options)
+
+      active_scope.ids.each do |id|
         enr = Enrollment.find_by(id: id)
         enr.publish_as_v2 if enr
       end


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-6959)


## Purpose 
We are addressing occasional deadlocks when calling `update_all` on student
enrollments.

## Approach 
When we try to update the `last_activity_at` on enrollments, sometimes
we have two and one has `deleted` activity_state. This is causing a
deadlock with transactions that look something like this:

```rb
UPDATE "public"."enrollments"
SET "total_activity_time" = 26978,
    "last_activity_at"   = '2024-11-15 17:19:59.273329'
WHERE "enrollments"."course_id" = 33484
  AND "enrollments"."user_id" = 240618; /*controller:submissions_api,action:for_students,hostname:75a8ffb08c13,pid:25784,context_id:5bef41bb-6174-4b00-80a7-0e03a652d607,line:/config/initializers/active_record.rb:960:in `update_all'*/

UPDATE "public"."enrollments"
SET "total_activity_time" = 26978,
    "last_activity_at"    = '2024-11-15 17:19:59.363693'
WHERE "enrollments"."course_id" = 33484
  AND "enrollments"."user_id" = 240618; /*controller:context_modules,action:content_tag_assignment_data,hostname:dc763854c4a3,pid:26708,context_id:e0110d0c-d0f7-4ad6-ae28-bccd5949023b,line:/config/initializers/active_record.rb:960:in `update_all'*/
```

We are assuming for the case of a student enrollment, there should only
be one, per course, per student. But we have two in these examples, all
including `deleted` ones.

## Testing
We may need to interogate the specs in the virtual box before we
continue with this change.


