### PR TITLE
KAPE-5194: Hide old custom placement button

### DIFF
--- a/app/views/jst/courses/roster/rosterUser.handlebars
+++ b/app/views/jst/courses/roster/rosterUser.handlebars
@@ -93,7 +93,7 @@
         <li><a href="#" data-event="editRoles"><i class="icon-edit" aria-hidden="true"></i> {{#t}}Edit Role{{/t}}</a></li>
       {{/if}}
       {{#if canCustomPlacement}}
-        <li>
+        <li style="display:none">
           <a href="#" data-event="editEnrollments">
             <i class="icon-edit" aria-hidden="true"></i> Custom Placement
           </a>


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/KAPE-5194)

## Purpose 
Hide Custom Placement in UI

## Approach 
Add "display: none" to list item element

## Testing
WIP - I'm trying to figure out how to run specs

## Screenshots/Video
Before:
![image](https://github.com/user-attachments/assets/dc3a3647-731a-4eb7-8614-0caaa9c50055)
After:
![image](https://github.com/user-attachments/assets/83e37efc-7c5d-47f2-a154-82240912fd6b)