### PR TITLE
PLT-14101 Increase sample rate to always be 1 in 10000 for transactions other than grade passback

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -54,7 +54,7 @@ if settings.present?
       return 1 if rack_env && rack_env.try(:[], 'QUERY_STRING')&.include?('sentry')
       transaction_context = sampling_context[:transaction_context]
       return 0.001 if transaction_context[:name].match?(/grade_passback$/)
-      0.0
+      0.0001
     end
   end
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/TEAM-NUMBER)

## Purpose 
<!-- what/why -->
We're experiencing issues with grade passback due to poes being under extreme pressure making ~600 queries a second on other tasks. Add a low sample rate for canvas as a whole, so we can work out which transaction is causing this.

## Approach 
<!-- how -->
Increase default sample rate to 0.0001

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->

## Screenshots/Video
<!-- show before/after of the change if possible -->
