### PR TITLE
(B) QTY-8152: Change "Oauth2::Error" to OAuth2::Error with a capital "A"

### DIFF
--- a/app/controllers/login/oauth2_controller.rb
+++ b/app/controllers/login/oauth2_controller.rb
@@ -37,7 +37,7 @@ class Login::Oauth2Controller < Login::OauthBaseController
 
       begin
         token = @aac.get_token(params[:code], oauth2_login_callback_url)
-      rescue Oauth2::Error => e
+      rescue OAuth2::Error => e
         return render_json_unauthorized
       end
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-8152)

## Purpose 
<!-- what/why -->
So that the rescue does not throw a `NameError` due to not recognizing `Oauth2::Error`

The underlying error being thrown should be `OAuth2::Error` with a capital "A".

The rescue that is now throwing the `NameError` was introduced ~6 months ago https://github.com/StrongMind/canvas-lms/commit/0209c2d16eeb274b36615397241de27e59cb3d43

## Approach 
<!-- how -->
Update constant in rescue block

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
N/A

## Screenshots/Video
<!-- show before/after of the change if possible -->
Underlying error:
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/7b949db3-b46e-4692-96fe-618afe64febe">

