### PR TITLE
(B) QTY-10234: Fix visual bug for conference updates

### DIFF
--- a/app/coffeescripts/views/conferences/EditConferenceView.coffee
+++ b/app/coffeescripts/views/conferences/EditConferenceView.coffee
@@ -57,6 +57,7 @@ define [
           @model.set(data)
           @model.trigger('startSync')
         success: (data) =>
+          data = deparam($.param(data)).web_conference
           @model.set(data)
           @model.trigger('sync')
         error: =>


### PR DESCRIPTION
[QTY-10234](https://strongmind.atlassian.net/browse/QTY-10234)

## Purpose 
There is a visual bug when a user updates a conference for a course

## Approach 
Update state after the update is successful

## Testing
Will be testing on new-id-sandbox


[QTY-10234]: https://strongmind.atlassian.net/browse/QTY-10234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ