### PR TITLE
(B) QTY-10234: Force the conference form to refresh with a submit

### DIFF
--- a/app/coffeescripts/views/conferences/EditConferenceView.coffee
+++ b/app/coffeescripts/views/conferences/EditConferenceView.coffee
@@ -57,7 +57,6 @@ define [
           @model.set(data)
           @model.trigger('startSync')
         success: (data) =>
-          data = deparam($.param(data)).web_conference
           @model.set(data)
           @model.trigger('sync')
         error: =>
@@ -85,6 +84,7 @@ define [
     update: =>
       @$('form').submit()
       @close()
+      @$('form').submit() if !@model.isNew()
 
     onClose: =>
       window.router.navigate('')


### PR DESCRIPTION
[QTY-10234](https://strongmind.atlassian.net/browse/QTY-10234)

## Purpose 
Force a refresh, I timeboxed other solutions to manually update the local state.. settled on brute forcing the issue and forced a form reset on update.

## Approach 
Resubmit the form if updating as the creation flow does not seem to have the original issue

## Testing
Tested on the canvas vm via team viewer


[QTY-10234]: https://strongmind.atlassian.net/browse/QTY-10234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ