### PR TITLE
QTY-11338 Update the gh token b/c the old one is probably expired

### DIFF
--- a/.github/workflows/notify_canvas_docker.yml
+++ b/.github/workflows/notify_canvas_docker.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - name: Github REST API Call
       env:
-        CI_TOKEN: ${{ secrets.CI_TOKEN }}
+        CI_TOKEN: ${{ secrets.DEVOPS_GH_TOKEN }}
         PARENT_REPO: StrongMind/canvas-docker
         PARENT_BRANCH: main
         WORKFLOW_ID: 37283728


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-11338)

## Purpose 
<!-- what/why -->
Address the action run failure, `curl: (22) The requested URL returned error: 401`
## Approach 
<!-- how -->
This pull request includes a change to the `.github/workflows/notify_canvas_docker.yml` file. The change updates the environment variable used for the GitHub REST API call.

* [`.github/workflows/notify_canvas_docker.yml`](diffhunk://#diff-9517137574fa4a237484d22245054f6dbc793a423c188facd9afa8db63577f61L24-R24): Changed the environment variable `CI_TOKEN` to use `secrets.DEVOPS_GH_TOKEN` instead of `secrets.CI_TOKEN`.
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
merge run and verify
