### PR TITLE
BEL-4804 Send errors for slow transactions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,6 +52,7 @@ class ApplicationController < ActionController::Base
   include Canvas::RequestForgeryProtection
   protect_from_forgery with: :exception
 
+  before_action :register_request_id_in_thread
   # load_user checks masquerading permissions, so this needs to be cleared first
   before_action :clear_cached_contexts
   prepend_before_action :load_user, :load_account
@@ -90,6 +91,9 @@ class ApplicationController < ActionController::Base
     crumb.html_safe
   }, :root_path, class: 'home')
 
+  def register_request_id_in_thread
+    Thread.current.thread_variable_set('request_id', request.uuid)
+  end
   ##
   # Sends data from rails to JavaScript
   #

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,11 +1,18 @@
-Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: 55
-class SlowTransactionError < RuntimeError; end
+Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: 50
+class SlowTransactionError < RuntimeError
+  attr :backtrace
+  def initialize(backtrace)
+    @backtrace = backtrace
+  end
+end
 Rack::Timeout.register_state_change_observer(:check_for_slow_requests) do |env|
   unless env["sentry_sent"]
     info = env[::Rack::Timeout::ENV_INFO_KEY]
+    request_id = env["action_dispatch.request_id"]
     if info.service && info.service > 15
-      Sentry.capture_exception(SlowTransactionError.new)
       env["sentry_sent"] = true
+      backtrace = Thread.list.find { |thread| thread.thread_variable_get("request_id") == request_id}.backtrace
+      Sentry.capture_exception(SlowTransactionError.new(backtrace))
     end
   end
 end

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,1 +1,11 @@
 Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: 55
+class SlowTransactionError < RuntimeError; end
+Rack::Timeout.register_state_change_observer(:check_for_slow_requests) do |env|
+  unless env["sentry_sent"]
+    info = env[::Rack::Timeout::ENV_INFO_KEY]
+    if info.service && info.service > 15
+      Sentry.capture_exception(SlowTransactionError.new)
+      env["sentry_sent"] = true
+    end
+  end
+end


### PR DESCRIPTION


[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4804)

## Purpose 
<!-- what/why -->
Capture more information for slow transactions that we do not wish to timeout.
## Approach 
<!-- how -->
Dealing with the last of these grade_passback errors, we're not getting Rack Timeouts for some of them. This will produce a different exception and send it to sentry, but not kill the transaction.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Checked that the change works in a local central instance. Will need to double check on CDCR or new-id-sandbox.