### PR TITLE
BEL-4804 Change time warning to 30 seconds.

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -9,7 +9,7 @@ Rack::Timeout.register_state_change_observer(:check_for_slow_requests) do |env|
   unless env["sentry_sent"]
     info = env[::Rack::Timeout::ENV_INFO_KEY]
     request_id = env["action_dispatch.request_id"]
-    if info.service && info.service > 15
+    if info.service && info.service > 30
       env["sentry_sent"] = true
       backtrace = Thread.list.find { |thread| thread.thread_variable_get("request_id") == request_id}.backtrace
       Sentry.capture_exception(SlowTransactionError.new(backtrace))


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4804)

## Purpose 
<!-- what/why -->
Reduce the initial number of slow transaction exceptions into sentry.

## Approach 
<!-- how -->
Change the timeout to 30 seconds.
