### PR TITLE
BEL-4804 Solve bug with stack trace

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,7 +92,7 @@ class ApplicationController < ActionController::Base
   }, :root_path, class: 'home')
 
   def register_request_id_in_thread
-    Thread.current.thread_variable_set('request_id', request.uuid)
+    Thread.current.thread_variable_set('request_id', env[::Rack::Timeout::ENV_INFO_KEY].id)
   end
   ##
   # Sends data from rails to JavaScript

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,1 +1,19 @@
 Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: 50
+class SlowTransactionError < RuntimeError
+  attr :backtrace
+  def initialize(backtrace)
+    @backtrace = backtrace
+  end
+end
+Rack::Timeout.register_state_change_observer(:check_for_slow_requests) do |env|
+  unless env["sentry_sent"]
+    info = env[::Rack::Timeout::ENV_INFO_KEY]
+    Rails.logger.info("Rack Timeout Request Details ID: #{info.id}")
+    request_id = info.id
+    if info.service && info.service > 30
+      env["sentry_sent"] = true
+      backtrace = Thread.list.find { |thread| thread.thread_variable_get("request_id") == request_id}.backtrace
+      Sentry.capture_exception(SlowTransactionError.new(backtrace))
+    end
+  end
+end

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -8,7 +8,6 @@ end
 Rack::Timeout.register_state_change_observer(:check_for_slow_requests) do |env|
   unless env["sentry_sent"]
     info = env[::Rack::Timeout::ENV_INFO_KEY]
-    Rails.logger.info("Rack Timeout Request Details ID: #{info.id}")
     request_id = info.id
     if info.service && info.service > 30
       env["sentry_sent"] = true


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4804)

## Purpose 
<!-- what/why -->
Solve bug with stack trace showing the main thread in sentry, preventing us from gaining more telemetry to work out slow requests (in particular for grade passback, but elsewhere also).
## Approach 
<!-- how -->
We originally tested the 30 second soft timeout sentry errors with central, as we had no easy way to test them with canvas. Turns out that Canvas removes the ActionDispatch request id middleware, which we were dependent upon.

Use the rack timeout requestdetails id instead to grab the correct thread.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Tested in dev and ensured the backtrace reached the logger.