### PR TITLE
QTY-11777: Add missing announcement button

### DIFF
--- a/app/views/jst/announcements/IndexView.handlebars
+++ b/app/views/jst/announcements/IndexView.handlebars
@@ -96,6 +96,14 @@
     <h5 style="padding-left: 1.5rem;">
       {{#t "there_are_no_announcements_show"}}There are no announcements to show{{/t}}
     </h5>
+    {{#if options.permissions.create}}
+      <div style="margin:auto; text-align: center; margin-top: 20px">
+        <a href="{{new_topic_url}}" class="btn btn-large btn-primary">
+          <i class="icon-plus"></i>
+          {{#t}}Announcement{{/t}}
+        </a>
+      </div>
+    {{/if}}
     <h3 class="announcement-heading expired">Expired</h3>
     <ul id="expired-announcements" class="sm-announcements"></ul>
   {{else}}


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-11777)

## Purpose 
<!-- what/why -->
Sometimes the 'add announcement' button is missing from the page.

## Approach 
<!-- how -->
There was a condition where if there was expired announcements and no active announcements, the 'add announcement' button would not render. Added logic to render the button in this condition if the user has the correct permissions. 

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Plan to recreate the issue in New-Id-Sandbox and verify this fixes the issue.

## Screenshots/Video
<!-- show before/after of the change if possible -->
Current issue, where the 'add announcement' button is missing:
<img width="1525" alt="Screenshot 2025-02-03 at 2 34 16 PM" src="https://github.com/user-attachments/assets/9ab28ead-0be0-4e99-81a3-355e1c3b096e" />

