### PR TITLE
QTY-13818: Update Slow Transaction Sentry Behavior

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,23 +1,32 @@
 Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: 50
 class SlowTransactionError < RuntimeError
-  attr :backtrace
-  def initialize(backtrace)
+  attr_reader :backtrace, :duration
+
+  def initialize(backtrace, duration)
     @backtrace = backtrace
+    @duration = duration
+  end
+
+  def message
+    "Request took too long (#{duration}s)."
   end
 end
+
 Rack::Timeout.register_state_change_observer(:check_for_slow_requests) do |env|
   unless env["sentry_sent"]
     info = env[::Rack::Timeout::ENV_INFO_KEY]
     request_id = info.id
-    if info.service && info.service > 30
+    slow_threshold = 50
+    actual_time = info.service
+
+    if actual_time && actual_time > slow_threshold
       env["sentry_sent"] = true
       begin
         slow_thread = Thread.list.find { |thread| thread.thread_variable_get("request_id") == request_id}
-        slow_thread.thread_variable_get('sentry_hub').capture_exception(SlowTransactionError.new(slow_thread.backtrace))
+        slow_thread.thread_variable_get('sentry_hub').capture_exception(SlowTransactionError.new(slow_thread.backtrace, actual_time))
       rescue
          # Ignored
       end
     end
   end
 end
-

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -16,7 +16,7 @@ Rack::Timeout.register_state_change_observer(:check_for_slow_requests) do |env|
   unless env["sentry_sent"]
     info = env[::Rack::Timeout::ENV_INFO_KEY]
     request_id = info.id
-    slow_threshold = 50
+    slow_threshold = ENV.fetch("SLOW_QUERY_THRESHOLD", 50).to_i
     actual_time = info.service
 
     if actual_time && actual_time > slow_threshold

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,4 +1,4 @@
-Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: 50
+Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: 55
 class SlowTransactionError < RuntimeError
   attr_reader :backtrace, :duration
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -40,6 +40,7 @@ if settings.present?
       Folio::InvalidPage
       Turnitin::Errors::SubmissionNotScoredError
       ActiveRecord::ConcurrentMigrationError
+      Rack::Timeout::RequestTimeoutException
     }
     config.before_send = lambda do |event, hint|
       if event.exception&.instance_variable_get(:@values)&.first&.type == "ActiveRecord::RecordInvalid" && hint[:exception].message == "Validation failed: Email is invalid"


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-13818)

## Purpose 
* Update Sentry to be less noisy for Canvas-lms
* Allow the threshold for reporting slow queries to be adjustable via an ENV variable

## Approach 
* Make Rack Timeout Exception throw after 55 seconds (bumped up from 50 seconds)
* Report slow queries when they take 50 seconds instead of 30 seconds
* Determine slow queries from an ENV variable if it exists, otherwise default to 50 seconds
* Have Sentry ignore Rack Timeouts, since we will report them via SlowQuery errors already.
