### PR TITLE
(B) PLT-16012: Limit log_page_view to UI driven page views

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,7 +67,7 @@ class ApplicationController < ActionController::Base
   before_action :require_reacceptance_of_terms
   before_action :clear_policy_cache
   before_action :setup_live_events_context
-  after_action :log_page_view
+  after_action :log_page_view, unless: -> { request.path.include?("api/v1/") }
   after_action :discard_flash_if_xhr
   after_action :cache_buster
   before_action :initiate_session_from_token


### PR DESCRIPTION
[PLT-16012](https://strongmind.atlassian.net/browse/PLT-16012)

## Purpose 
Data pipeline is getting slammed by page view nouns and some of these are from API clients hitting api endpoints hundreds of thousands of times counting towards "page_views" 

page_views should not be considered when coming from an api call

## Approach 
Exclude logging page views on api calls

There are unfortunately routes with "api/v1/" going to normal controllers sharing the same endpoint as normal controllers.. so going into all api controllers and skipping this action would be a heavy lift
