### PR TITLE
QTY-11193: Grant `rds_superuser` permissions to `new_canvas` role if both roles exist

### DIFF
--- a/db/migrate/20250212185316_grant_privileges_to_new_canvas.rb
+++ b/db/migrate/20250212185316_grant_privileges_to_new_canvas.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class GrantPrivilegesToNewCanvas < ActiveRecord::Migration[5.0]
+  tag :predeploy
+
+  def change
+    reversible do |dir|
+      dir.up do
+        execute grants_sql
+      end
+
+      dir.down do
+        # DO NOTHING
+      end
+    end
+  end
+
+  def grants_sql
+    <<-SQL.squish
+      DO $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1
+          FROM pg_catalog.pg_roles
+          WHERE rolname = 'new_canvas'
+        ) THEN
+          IF EXISTS (
+            SELECT 1
+            FROM pg_catalog.pg_roles
+            WHERE rolname = 'rds_superuser'
+          ) THEN
+            GRANT rds_superuser TO new_canvas;
+          END IF;
+        END IF;
+      END;
+      $$;
+     SQL
+  end
+end


### PR DESCRIPTION
Because when we partition new quiz_submission tables, this role is not authorized

[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-11193)

## Purpose 
Addressing [this](https://strongmind-4j.sentry.io/issues/6102195487/?referrer=jira_integration) sentry issue, we want to endow the `canvas_user` with superuser capabilites. 

## Approach 
* We write a migration so we don't have to manually configure these roles for any problematic canvas instance. We don't wanna ever have to do it again.
* For RDS, I think the closest role to an actual superuser (since they don't let you make superusers), is `rds_superuser`.
* We need to only apply these changes for canvas instances where these roles exist.
* Not a huge fan of PGPSQL procedural language, but here I think it's necessary to not explode when migrations run in a canvas instance where either of these roles do not exist (or if they don't exist in the future).

## Testing
Tested locally, by manually creating and revoking `rds_superuser` and `new_canvas` roles to ensure the migration does not break any app without these, but still works if they exist.

