### PR TITLE
(B) QTY-14666: Preload context module tags

### DIFF
--- a/app/controllers/assignment_groups_controller.rb
+++ b/app/controllers/assignment_groups_controller.rb
@@ -325,6 +325,9 @@ class AssignmentGroupsController < ApplicationController
 
     assignments_by_group = assignments.group_by(&:assignment_group_id)
     preloaded_attachments = user_content_attachments(assignments, context)
+    
+    # Preload context_module_tags for all assignments to avoid N+1 queries in context_tag_id
+    ContentTag.preload_for_collection(assignments, :context_module_tags) unless assignments.empty?
 
     unless assignment_excludes.include?('in_closed_grading_period')
       closed_grading_period_hash =

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -294,7 +294,9 @@ class Assignment < ActiveRecord::Base
   )
 
   def context_tag_id
-    if context_module_tags
+    if context_module_tags.loaded?
+      context_module_tags.first&.id
+    elsif context_module_tags
       context_module_tags.first.id unless context_module_tags.first.nil?
     end
   end

--- a/lib/api/v1/assignment_group.rb
+++ b/lib/api/v1/assignment_group.rb
@@ -51,6 +51,9 @@ module Api::V1::AssignmentGroup
       unless includes.include?('module_ids') || group.context.grants_right?(user, session, :read_as_admin)
         Assignment.preload_context_module_tags(assignments) # running this again is fine
       end
+      
+      # Always preload context_module_tags to avoid N+1 queries in context_tag_id
+      ContentTag.preload_for_collection(assignments, :context_module_tags) unless assignments.empty?
 
       unless opts[:exclude_response_fields].include?('in_closed_grading_period')
         closed_grading_period_hash = opts[:closed_grading_period_hash] ||


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-14666)

## Purpose 
<!-- what/why -->
Without preloading, when the code iterates through each assignment and calls context_tag_id, it triggers a separate database query for each assignment to fetch its associated context module tags. This is a classic N+1 query problem:
 - One query to fetch all assignments
 - N additional queries (one per assignment) to fetch each assignment's context module tags
For courses with many assignments, this can lead to hundreds of individual database queries, causing significant performance degradation.

## Approach 
<!-- how -->
The preloading approach solves this by:
 - Loading all assignments in a single query
 - Loading all related context module tags for all assignments in a single additional query
 - Associating the loaded tags with their respective assignments in memory
This reduces the number of database queries from N+1 to just 2, regardless of how many assignments exist.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
N/A

## Screenshots/Video
<!-- show before/after of the change if possible -->
