### PR TITLE
(B) BEL-5313: Add Sentry error reporting for attendance service

### DIFF
--- a/lib/authentication_methods.rb
+++ b/lib/authentication_methods.rb
@@ -193,7 +193,9 @@ module AuthenticationMethods
             else
               Rails.cache.write("unlocked_#{current_integration_id}", true, :expires_in => 5.minutes)
             end
-          rescue
+          rescue => exception
+            Canvas::Errors.capture_exception(:attendance_service_check, exception)
+            Rails.cache.write("unlocked_#{current_integration_id}", true, :expires_in => 5.minutes)
           end
         end
       end


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-5313)

## Purpose 
<!-- what/why -->
We're currently silently failing when we fail to talk to the attendance service.  This was originally done because the maintainers of the codebase were not using sentry, and it is important for the service to remain up (fail open) when attendance is down.

## Approach 
<!-- how -->
Use the canvas errors capture service to send errors to sentry.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Will test in stage before sending to prod.
