### PR TITLE
(S) QTY-15239: Replace 401, 404, 500 html pages with central's

### DIFF
--- a/public/401.html
+++ b/public/401.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="full-page">
 <head>
-    <title>We're sorry, but something went wrong (500)</title>
+    <title>Unauthorized (401)</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://cdn.strongmind.com/backpack-ui/latest/assets/css/BackpackUI.css" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -37,10 +37,18 @@
         .rive-position {
             display: flex;
             justify-content: center;
+            align-items: center;
+            width: 100%;
+            overflow: hidden;
         }
         .rive-size {
-            width: 65%;
-            height: 65%;
+            max-width: 100%;
+            height: auto;
+        }
+        .animation-container {
+            width: 100%;
+            max-width: 800px;
+            margin: 0 auto;
         }
         .text-style {
             font-family: "Open Sans", sans-serif;
@@ -69,21 +77,22 @@
         }
     </style>
 </head>
+
 <body class="strongmind-ui full-page">
 <main class="flex flex-col items-center min-h-screen pt-2">
     <div class="w-full max-w-6xl px-4 mx-auto">
         <div class="flex flex-col items-center gap-4">
             <!-- Rive Animation -->
-            <div class="w-full max-w-xl">
-                <div class="rive-position" data-controller="rive" data-rive-animation="500_page_error">
-                    <canvas id="500" width="500" height="500" class="rive-size" data-rive-target="pageError"></canvas>
+            <div class="animation-container">
+                <div class="rive-position" data-controller="rive" data-rive-animation="401_page_error" data-rive-statemachines="401-sm">
+                    <canvas id="401" width="1960" height="829" class="rive-size" data-rive-target="pageError"></canvas>
                 </div>
             </div>
 
             <!-- Error Text -->
             <div class="text-center md:text-left">
-                <p class="mb-1 text-style text-size">Oh snap! Something broke!</p>
-                <p class="text-style">Looks like a server issue (it's not you, it's us).</p>
+                <p class="mb-1 text-style text-size">Uh oh! You don't have access to this page!</p>
+                <p class="text-style">Please make sure you have the proper permissions or contact your administrator.</p>
             </div>
 
             <!-- Action Section -->

--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="full-page">
 <head>
-    <title>We're sorry, but something went wrong (500)</title>
+    <title>The page you were looking for doesn't exist (404)</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://cdn.strongmind.com/backpack-ui/latest/assets/css/BackpackUI.css" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -37,10 +37,18 @@
         .rive-position {
             display: flex;
             justify-content: center;
+            align-items: center;
+            width: 100%;
+            overflow: hidden;
         }
         .rive-size {
-            width: 65%;
-            height: 65%;
+            max-width: 100%;
+            height: auto;
+        }
+        .animation-container {
+            width: 100%;
+            max-width: 800px;
+            margin: 0 auto;
         }
         .text-style {
             font-family: "Open Sans", sans-serif;
@@ -69,21 +77,22 @@
         }
     </style>
 </head>
+
 <body class="strongmind-ui full-page">
 <main class="flex flex-col items-center min-h-screen pt-2">
     <div class="w-full max-w-6xl px-4 mx-auto">
         <div class="flex flex-col items-center gap-4">
             <!-- Rive Animation -->
-            <div class="w-full max-w-xl">
-                <div class="rive-position" data-controller="rive" data-rive-animation="500_page_error">
-                    <canvas id="500" width="500" height="500" class="rive-size" data-rive-target="pageError"></canvas>
+            <div class="animation-container">
+                <div class="rive-position" data-controller="rive" data-rive-animation="404_page_error">
+                    <canvas id="404" width="1960" height="829" class="rive-size" data-rive-target="pageError"></canvas>
                 </div>
             </div>
 
             <!-- Error Text -->
             <div class="text-center md:text-left">
-                <p class="mb-1 text-style text-size">Oh snap! Something broke!</p>
-                <p class="text-style">Looks like a server issue (it's not you, it's us).</p>
+                <p class="mb-1 text-style text-size">Whoops! Page Not Found</p>
+                <p class="text-style">We can't find what you're looking for. The page may have been moved or deleted.</p>
             </div>
 
             <!-- Action Section -->


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-15239)

## Purpose 
Standardize error HTML pages

## Approach 
Add 401, 404, and replace 500 html pages with central's error pages

## Testing
Go to the <url>/401, <url>/404, <url>/500 to verify

## Screenshots/Video

<img width="1386" alt="Screenshot 2025-03-18 at 11 44 40 AM" src="https://github.com/user-attachments/assets/12cc70f9-2eb4-4418-9d4f-6e3d280328da" />
<img width="1386" alt="Screenshot 2025-03-18 at 11 44 27 AM" src="https://github.com/user-attachments/assets/406d9c72-7b32-443a-9870-3f71dddd1a3d" />
<img width="1397" alt="Screenshot 2025-03-18 at 11 44 17 AM" src="https://github.com/user-attachments/assets/0b3455ea-1000-451d-ae53-75b68b1e8679" />
