### PR TITLE
Add advisory locking around user updates

### DIFF
--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -495,10 +495,14 @@ class Enrollment < ActiveRecord::Base
   end
 
   def conclude
-    self.workflow_state = "completed"
-    self.completed_at = Time.now
-    self.user.touch
-    self.save
+    User.transaction do
+      self.user.with_lock do
+        self.workflow_state = "completed"
+        self.completed_at = Time.now
+        self.user.touch
+        save
+      end
+    end
   end
 
   def unconclude


### PR DESCRIPTION
[QTY-17506](https://strongmind.atlassian.net/browse/QTY-17506)

## Purpose
Fix PostgreSQL deadlock errors occurring when multiple enrollment conclusions are processed concurrently for the same user. The deadlock happens when two processes attempt to update the same user record (via user.touch) in different transaction orders, creating a circular wait condition that causes one transaction to fail with PG::TRDeadlockDetected.
## Approach
Wrap the enrollment conclusion logic in a database transaction with explicit row-level locking on the user record using with_lock. This ensures that when multiple enrollments for the same user are being concluded simultaneously, they will be processed sequentially rather than concurrently, eliminating the deadlock condition.
Changes made:

Added User.transaction block around the entire conclude method
Added self.user.with_lock to acquire an exclusive lock on the user record before any updates
This forces concurrent processes to wait in line rather than creating circular dependencies

[QTY-17506]: https://strongmind.atlassian.net/browse/QTY-17506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ