### PR TITLE
Canvas completed nil error

### DIFF
--- a/app/helpers/assessment_request_helper.rb
+++ b/app/helpers/assessment_request_helper.rb
@@ -18,9 +18,9 @@
 module AssessmentRequestHelper
 
   def submission_author_name_for(assessment_request, prepend = '')
-    submission = @submission || assessment_request.submission
+    submission = @submission || assessment_request&.submission
     if (assessment_request && can_do(assessment_request, @current_user, :read_assessment_user)) || !assessment_request
-      "#{prepend}#{context_user_name(@context, submission.user)}"
+      "#{prepend}#{context_user_name(@context, submission&.user)}"
     else
       "#{prepend}#{I18n.t(:anonymous_user, 'Anonymous User')}"
     end

--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -37,6 +37,8 @@ module AssignmentsHelper
   end
 
   def student_peer_review_link_for(context, assignment, assessment)
+    return '' if assessment.nil?
+    
     options = assessment.completed? ? completed_link_options : in_progress_link_options
     icon_class = assessment.completed? ? 'icon-check' : 'icon-warning'
     text = safe_join [

--- a/spec/helpers/assignments_helper_spec.rb
+++ b/spec/helpers/assignments_helper_spec.rb
@@ -119,4 +119,16 @@ describe AssignmentsHelper do
       expect(turnitin_active?).to be_falsey
     end
   end
+
+  describe "#student_peer_review_link_for" do
+    before(:once) do
+      course_with_teacher(active_all: true)
+      student_in_course(active_all: true)
+      assignment_model(course: @course)
+    end
+
+    it "returns empty string when assessment is nil" do
+      expect(student_peer_review_link_for(@course, @assignment, nil)).to eq('')
+    end
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix `NoMethodError: undefined method 'completed?' for nil:NilClass` by adding nil checks in helper methods and a corresponding test.

This PR addresses a Sentry error where `completed?` was called on a `nil` assessment object within the `student_peer_review_link_for` helper. It also adds safe navigation to `submission_author_name_for` to prevent similar nil errors and includes a test case for the `student_peer_review_link_for` helper.

[Slack Thread](https://flipswitch.slack.com/archives/C03F3V2EF7E/p1772471629053489?thread_ts=1772471629.053489&cid=C03F3V2EF7E)

<div><a href="https://cursor.com/agents/bc-e5d96e4b-fe0d-5f04-b76d-a6f96345ac56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5d96e4b-fe0d-5f04-b76d-a6f96345ac56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->