### PR TITLE
NXT-8558: Add FERPA-compliant Sentry PII scrubbing

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -26,10 +26,72 @@ settings = ConfigFile.load("sentry")
 
 if settings.present?
 
+  # Inline PII scrubbing for FERPA compliance purposes.
+  # Mirrors PlatformSdk::Sentry::PiiScrubber::DEFAULT_PII_FIELDS but
+  # implemented inline because strongmind-platform-sdk requires
+  # Rails >= 7.1 / Ruby >= 2.6 (canvas-lms is Rails 5 / Ruby 2.5).
+  PII_FIELDS = [
+    :email, /\Aname\z/i, :first_name, :last_name, :student_name,
+    :username, :phone, :phone_number, :address, :street, :city,
+    :zip, :postal_code, :ssn, :social_security, :date_of_birth,
+    :dob, :birthday, :ip_address, /\Aip\z/i, :remote_ip,
+    :password, :password_confirmation, :token, :secret, :api_key,
+    :authorization
+  ].freeze
+  PII_FILTERED = '[FILTERED]'.freeze
+  PII_EMAIL_REGEX = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/
+
+  pii_filter = ActionDispatch::Http::ParameterFilter.new(PII_FIELDS)
+
+  scrub_hash = lambda do |hash|
+    hash.is_a?(Hash) ? pii_filter.filter(hash) : {}
+  end
+
+  scrub_user = lambda do |user_hash|
+    id = user_hash[:id] || user_hash['id']
+    scrubbed = scrub_hash.call(user_hash)
+    scrubbed[:id] = id if user_hash.key?(:id)
+    scrubbed['id'] = id if user_hash.key?('id')
+    scrubbed
+  end
+
+  scrub_request = lambda do |request|
+    if request.data.is_a?(Hash)
+      request.data = scrub_hash.call(request.data)
+    end
+    if request.headers.is_a?(Hash)
+      request.headers = scrub_hash.call(request.headers)
+    end
+    request.query_string = PII_FILTERED if request.query_string
+    request.cookies = PII_FILTERED if request.cookies
+  end
+
+  scrub_event = lambda do |event|
+    if event.user.is_a?(Hash)
+      event.user = scrub_user.call(event.user)
+    end
+    if event.extra.is_a?(Hash)
+      event.extra = scrub_hash.call(event.extra)
+    end
+    if event.contexts.is_a?(Hash)
+      event.contexts = scrub_hash.call(event.contexts)
+    end
+    scrub_request.call(event.request) if event.request
+    event
+  end
+
+  sentry_ignored_urls = [
+    %r{/up$}i, %r{/health_check$}i, %r{/favicon\.ico$}i,
+    %r{/robots\.txt$}i, %r{/nuclei.svg$}i, %r{/wp-admin}i,
+    %r{/cgi-bin}i, %r{/jmx-console}i, %r{/manager/html}i,
+    %r{/phpmyadmin}i, /.+\.php$/i, /.+\.ini$/i, /.+\.env$/i,
+    /.+\.txt$/i, /.+\.jsp$/i, /.+\.do$/i, /.+\.srf$/i,
+    /.+\.bak$/i, /.+\.cfml?$/i, /.+\.cgi$/i
+  ].freeze
+
   Sentry.init do |config|
     config.dsn = settings[:dsn]
     config.breadcrumbs_logger = [:sentry_logger, :http_logger]
-    config.capture_exception_frame_locals = true
     config.transport.ssl_verification = false
     config.release = Canvas.revision
     config.enabled_environments = %w[ production ]
@@ -42,24 +104,53 @@ if settings.present?
       ActiveRecord::ConcurrentMigrationError
       Rack::Timeout::RequestTimeoutException
     }
+
     config.before_send = lambda do |event, hint|
-      if event.exception&.instance_variable_get(:@values)&.first&.type == "ActiveRecord::RecordInvalid" && hint[:exception].message == "Validation failed: Email is invalid"
+      if event.exception&.instance_variable_get(:@values)&.
+           first&.type == "ActiveRecord::RecordInvalid" &&
+         hint[:exception].message ==
+           "Validation failed: Email is invalid"
         nil
       else
-        event
+        scrub_event.call(event)
       end
     end
 
+    config.before_breadcrumb = lambda do |breadcrumb, _hint|
+      if breadcrumb.data.is_a?(Hash)
+        breadcrumb.data = scrub_hash.call(breadcrumb.data)
+      end
+      if breadcrumb.message
+        breadcrumb.message = breadcrumb.message.gsub(
+          PII_EMAIL_REGEX, PII_FILTERED
+        )
+      end
+      breadcrumb
+    end
+
     config.traces_sampler = lambda do |sampling_context|
-      # if this is the continuation of a trace, just use that decision (rate controlled by the caller)
       unless sampling_context[:parent_sampled].nil?
         next sampling_context[:parent_sampled]
       end
       rack_env = sampling_context[:env]
-      return 1 if rack_env && rack_env.try(:[], 'QUERY_STRING')&.include?('sentry')
-      return 0.01 if rack_env && rack_env.try(:[], 'PATH_INFO') =~ /grade_passback$/
+      if rack_env &&
+         rack_env.try(:[], 'QUERY_STRING')&.include?('sentry')
+        return 1
+      end
+      if rack_env &&
+         rack_env.try(:[], 'PATH_INFO') =~ /grade_passback$/
+        return 0.01
+      end
 
       0.0001
+    end
+
+    config.before_send_transaction = lambda do |event, _hint|
+      if event.transaction_info[:source] == :url &&
+         sentry_ignored_urls.any? { |u| event.transaction.match?(u) }
+        return nil
+      end
+      scrub_event.call(event)
     end
   end
 

--- a/spec/lib/sentry_pii_scrubbing_spec.rb
+++ b/spec/lib/sentry_pii_scrubbing_spec.rb
@@ -1,0 +1,178 @@
+#
+# Copyright (C) 2015 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+require_relative "../spec_helper"
+
+# Inline PII scrubbing for Sentry events (for FERPA compliance purposes).
+# Mirrors PlatformSdk::Sentry::PiiScrubber but uses Rails 5-compatible
+# ActionDispatch::Http::ParameterFilter as strongmind-platform-sdk
+# requires Rails >= 7.1.
+describe "Sentry PII Scrubbing" do
+  let(:pii_fields) do
+    [
+      :email, /\Aname\z/i, :first_name, :last_name, :student_name,
+      :username, :phone, :phone_number, :address, :street, :city,
+      :zip, :postal_code, :ssn, :social_security, :date_of_birth,
+      :dob, :birthday, :ip_address, /\Aip\z/i, :remote_ip,
+      :password, :password_confirmation, :token, :secret, :api_key,
+      :authorization
+    ]
+  end
+
+  let(:pii_filter) do
+    ActionDispatch::Http::ParameterFilter.new(pii_fields)
+  end
+
+  let(:pii_email_regex) do
+    /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/
+  end
+
+  let(:filtered) { '[FILTERED]' }
+
+  describe "ParameterFilter field scrubbing" do
+    it "scrubs email fields" do
+      result = pii_filter.filter(
+        email: "student@example.com", id: "abc-123"
+      )
+      expect(result[:email]).to eq(filtered)
+      expect(result[:id]).to eq("abc-123")
+    end
+
+    it "scrubs name fields via regex anchor" do
+      result = pii_filter.filter(name: "Jane Doe", role: "student")
+      expect(result[:name]).to eq(filtered)
+      expect(result[:role]).to eq("student")
+    end
+
+    it "does not scrub partial name matches like username" do
+      result = pii_filter.filter(
+        username: "jdoe", display_name: "Jane"
+      )
+      expect(result[:username]).to eq(filtered)
+      expect(result[:display_name]).to eq("Jane")
+    end
+
+    it "scrubs first_name and last_name" do
+      result = pii_filter.filter(
+        first_name: "Victor", last_name: "Smith", grade: "A"
+      )
+      expect(result[:first_name]).to eq(filtered)
+      expect(result[:last_name]).to eq(filtered)
+      expect(result[:grade]).to eq("A")
+    end
+
+    it "scrubs student_name" do
+      result = pii_filter.filter(
+        student_name: "Violet Jones", course: "Math 101"
+      )
+      expect(result[:student_name]).to eq(filtered)
+      expect(result[:course]).to eq("Math 101")
+    end
+
+    it "scrubs contact fields" do
+      result = pii_filter.filter(
+        phone: "555-1234", address: "123 Main St",
+        city: "Phoenix", zip: "85001"
+      )
+      expect(result[:phone]).to eq(filtered)
+      expect(result[:address]).to eq(filtered)
+      expect(result[:city]).to eq(filtered)
+      expect(result[:zip]).to eq(filtered)
+    end
+
+    it "scrubs sensitive identifiers" do
+      result = pii_filter.filter(
+        ssn: "123-45-6789", date_of_birth: "2010-05-15",
+        ip_address: "192.168.1.1"
+      )
+      expect(result[:ssn]).to eq(filtered)
+      expect(result[:date_of_birth]).to eq(filtered)
+      expect(result[:ip_address]).to eq(filtered)
+    end
+
+    it "scrubs auth-related fields" do
+      result = pii_filter.filter(
+        password: "s3cret", token: "abc123",
+        api_key: "key-456", authorization: "Bearer xyz"
+      )
+      expect(result[:password]).to eq(filtered)
+      expect(result[:token]).to eq(filtered)
+      expect(result[:api_key]).to eq(filtered)
+      expect(result[:authorization]).to eq(filtered)
+    end
+
+    it "handles string keys the same as symbol keys" do
+      result = pii_filter.filter(
+        "email" => "student@example.com", "id" => "abc-123"
+      )
+      expect(result["email"]).to eq(filtered)
+      expect(result["id"]).to eq("abc-123")
+    end
+  end
+
+  describe "user hash scrubbing" do
+    it "preserves symbol id while scrubbing email" do
+      user_hash = { id: "user-42", email: "student@school.edu" }
+      scrubbed = pii_filter.filter(user_hash)
+      scrubbed[:id] = user_hash[:id]
+      expect(scrubbed[:id]).to eq("user-42")
+      expect(scrubbed[:email]).to eq(filtered)
+    end
+
+    it "preserves string id while scrubbing email" do
+      user_hash = { 'id' => "user-42", 'email' => "s@school.edu" }
+      scrubbed = pii_filter.filter(user_hash)
+      scrubbed['id'] = user_hash['id']
+      expect(scrubbed['id']).to eq("user-42")
+      expect(scrubbed['email']).to eq(filtered)
+    end
+  end
+
+  describe "email regex scrubbing in free text" do
+    it "scrubs email addresses from messages" do
+      message = "User john.doe@school.edu failed to submit"
+      scrubbed = message.gsub(pii_email_regex, filtered)
+      expect(scrubbed).to eq("User #{filtered} failed to submit")
+    end
+
+    it "scrubs multiple email addresses" do
+      message = "From a@b.com to c@d.org regarding enrollment"
+      scrubbed = message.gsub(pii_email_regex, filtered)
+      expect(scrubbed).to eq(
+        "From #{filtered} to #{filtered} regarding enrollment"
+      )
+    end
+
+    it "does not scrub non-email text" do
+      message = "Assignment submitted at 3pm for course 101"
+      scrubbed = message.gsub(pii_email_regex, filtered)
+      expect(scrubbed).to eq(message)
+    end
+  end
+
+  describe "non-hash input handling" do
+    it "returns empty hash for nil input" do
+      result = nil.is_a?(Hash) ? pii_filter.filter(nil) : {}
+      expect(result).to eq({})
+    end
+
+    it "returns empty hash for string input" do
+      result = "not a hash".is_a?(Hash) ? pii_filter.filter("x") : {}
+      expect(result).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
[NXT-8546](https://strongmind.atlassian.net/browse/NXT-8546)

## Purpose 
Add FERPA-compliant Sentry PII scrubbing to `canvas-lms` application.  Because `canvas-lms` runs on Rails 5 / Ruby 2.5, the `strongmind-platform-sdk` cannot be used (requires Rails >= 7.1 / Ruby >= 2.6).  PII scrubbing is therefore implemented inline using the same field list and logic as `PlatformSdk::Sentry::PiiScrubber` module.

## Approach 
- Remove `config.capture_exception_frame_locals = true` (was leaking local variable values potentially containing student names, emails, grades in error stack frames)
- Enhance existing `before_send` hook to scrub PII from error events (user context, extras, request data, headers, cookies, query strings) while preserving the existing `RecordInvalid` email validation filter
- Add `before_breadcrumb` hook that scrubs PII from breadcrumb data and email addresses from breadcrumb messages
- Add `before_send_transaction` hook with URL noise filtering (matching `PlatformSdk::Sentry.sentry_ignored_urls`) + PII scrubbing on transaction events
- All scrubbing uses `ActionDispatch::Http::ParameterFilter` (Rails 5 equivalent of `ActiveSupport::ParameterFilter`) with the same PII field list as the platform SDK
- Add RSpec unit tests for the new PII scrubbing logic

## Testing
- Unit tests created for PII field scrubbing, user hash scrubbing, email regex scrubbing, and non-hash input handling in new `spec/lib/sentry_pii_scrubbing_spec.rb` module



[NXT-8546]: https://strongmind.atlassian.net/browse/NXT-8546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ