### PR TITLE
NXT-8558: Add FERPA-compliant Sentry PII scrubbing

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -145,12 +145,14 @@ if settings.present?
       0.0001
     end
 
-    config.before_send_transaction = lambda do |event, _hint|
-      if event.transaction_info[:source] == :url &&
-         sentry_ignored_urls.any? { |u| event.transaction.match?(u) }
-        return nil
+    if config.respond_to?(:before_send_transaction=)
+      config.before_send_transaction = lambda do |event, _hint|
+        if event.transaction_info[:source] == :url &&
+           sentry_ignored_urls.any? { |u| event.transaction.match?(u) }
+          return nil
+        end
+        scrub_event.call(event)
       end
-      scrub_event.call(event)
     end
   end
 


### PR DESCRIPTION
[NXT-8546](https://strongmind.atlassian.net/browse/NXT-8546)

## Purpose 
Add FERPA-compliant Sentry PII scrubbing to `canvas-lms` application.  Because `canvas-lms` runs on Rails 5 / Ruby 2.5, the `strongmind-platform-sdk` cannot be used (requires Rails >= 7.1 / Ruby >= 2.6).  PII scrubbing is therefore implemented inline using the same field list and logic as `PlatformSdk::Sentry::PiiScrubber` module.

## Approach 
- Update custom initializer to skip scrubbing hook not available in older gem versions

## Testing
- Unit tests created for PII field scrubbing, user hash scrubbing, email regex scrubbing, and non-hash input handling in new `spec/lib/sentry_pii_scrubbing_spec.rb` module



[NXT-8546]: https://strongmind.atlassian.net/browse/NXT-8546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ