### PR TITLE
NXT-8585: Add FERPA-compliant stdout log PII scrubbing

### DIFF
--- a/config/initializers/pii_logging.rb
+++ b/config/initializers/pii_logging.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'pii_logging_formatter'
+
+logger = Rails.logger
+if logger.respond_to?(:formatter)
+  logger.formatter = PiiLoggingFormatter.new(
+    original_formatter: logger.formatter
+  )
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -26,22 +26,9 @@ settings = ConfigFile.load("sentry")
 
 if settings.present?
 
-  # Inline PII scrubbing for FERPA compliance purposes.
-  # Mirrors PlatformSdk::Sentry::PiiScrubber::DEFAULT_PII_FIELDS but
-  # implemented inline because strongmind-platform-sdk requires
-  # Rails >= 7.1 / Ruby >= 2.6 (canvas-lms is Rails 5 / Ruby 2.5).
-  PII_FIELDS = [
-    :email, /\Aname\z/i, :first_name, :last_name, :student_name,
-    :username, :phone, :phone_number, :address, :street, :city,
-    :zip, :postal_code, :ssn, :social_security, :date_of_birth,
-    :dob, :birthday, :ip_address, /\Aip\z/i, :remote_ip,
-    :password, :password_confirmation, :token, :secret, :api_key,
-    :authorization
-  ].freeze
-  PII_FILTERED = '[FILTERED]'.freeze
-  PII_EMAIL_REGEX = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/
+  require 'pii'
 
-  pii_filter = ActionDispatch::Http::ParameterFilter.new(PII_FIELDS)
+  pii_filter = ActionDispatch::Http::ParameterFilter.new(Pii::DEFAULT_FIELDS)
 
   scrub_hash = lambda do |hash|
     hash.is_a?(Hash) ? pii_filter.filter(hash) : {}
@@ -62,8 +49,8 @@ if settings.present?
     if request.headers.is_a?(Hash)
       request.headers = scrub_hash.call(request.headers)
     end
-    request.query_string = PII_FILTERED if request.query_string
-    request.cookies = PII_FILTERED if request.cookies
+    request.query_string = Pii::FILTERED if request.query_string
+    request.cookies = Pii::FILTERED if request.cookies
   end
 
   scrub_event = lambda do |event|
@@ -122,7 +109,7 @@ if settings.present?
       end
       if breadcrumb.message
         breadcrumb.message = breadcrumb.message.gsub(
-          PII_EMAIL_REGEX, PII_FILTERED
+          Pii::EMAIL_REGEX, Pii::FILTERED
         )
       end
       breadcrumb

--- a/lib/pii.rb
+++ b/lib/pii.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+#
+# Shared PII constants and regex patterns for FERPA/COPPA compliance purposes.
+# Mirrors PlatformSdk::Pii module from strongmind-platform-sdk but implemented
+# inline because canvas-lms cannot leverage the SDK (Rails 5 / Ruby 2.5).
+#
+# Used by both Sentry event scrubbing and stdout log message scrubbing.
+#
+module Pii
+  DEFAULT_FIELDS = [
+    :email, /\Aname\z/i, :first_name, :last_name, :student_name, :username,
+    :phone, :phone_number, :address, :street, :city, :zip, :postal_code,
+    :ssn, :social_security, :date_of_birth, :dob, :birthday,
+    :ip_address, /\Aip\z/i, :remote_ip,
+    :password, :password_confirmation, :token, :secret, :api_key,
+    :authorization
+  ].freeze
+
+  FILTERED = '[FILTERED]'
+
+  EMAIL_REGEX = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/
+  SSN_REGEX = /\b\d{3}-\d{2}-\d{4}\b/
+  PHONE_REGEX = /(?<!\d)(\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/
+
+  PII_PATTERNS = [EMAIL_REGEX, SSN_REGEX, PHONE_REGEX].freeze
+end

--- a/lib/pii_logging_formatter.rb
+++ b/lib/pii_logging_formatter.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative 'pii'
+
+#
+# Wraps an existing Logger formatter to scrub PII from log messages
+# before they reach STDOUT.
+#
+# Mirrors PlatformSdk::Logging::PiiFormatter but uses Rails 5-compatible
+# ActionDispatch::Http::ParameterFilter.
+#
+class PiiLoggingFormatter
+  attr_reader :original_formatter
+
+  def initialize(original_formatter: nil)
+    @original_formatter = original_formatter || ::Logger::Formatter.new
+    @param_filter = ActionDispatch::Http::ParameterFilter.new(
+      Pii::DEFAULT_FIELDS
+    )
+  end
+
+  def call(severity, timestamp, progname, message)
+    scrubbed = scrub_message(message)
+    @original_formatter.call(severity, timestamp, progname, scrubbed)
+  end
+
+  def respond_to_missing?(method, include_private = false)
+    @original_formatter.respond_to?(method, include_private) || super
+  end
+
+  def method_missing(method, *args, &block)
+    if @original_formatter.respond_to?(method)
+      @original_formatter.send(method, *args, &block)
+    else
+      super
+    end
+  end
+
+  private
+
+  def scrub_message(message)
+    case message
+    when Hash
+      @param_filter.filter(message)
+    when String
+      Pii::PII_PATTERNS.reduce(message) do |msg, pattern|
+        msg.gsub(pattern, Pii::FILTERED)
+      end
+    else
+      message
+    end
+  end
+end

--- a/script/verify_pii_scrubbing.rb
+++ b/script/verify_pii_scrubbing.rb
@@ -1,0 +1,319 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Standalone PII scrubbing verification script.
+# Runs with vanilla Ruby — no Rails, no Docker, no bundle required.
+#
+# Usage (from canvas-lms root):
+#   ruby script/verify_pii_scrubbing.rb
+
+require_relative '../lib/pii'
+require 'logger'
+
+PASS = "\u2705"
+FAIL = "\u274C"
+
+$results = { pass: 0, fail: 0 }
+
+def assert_equal(description, condition)
+  if condition
+    puts "  #{PASS} #{description}"
+    $results[:pass] += 1
+  else
+    puts "  #{FAIL} #{description}"
+    $results[:fail] += 1
+  end
+end
+
+def scrub_string(message)
+  Pii::PII_PATTERNS.reduce(message) do |msg, pattern|
+    msg.gsub(pattern, Pii::FILTERED)
+  end
+end
+
+# Lightweight stand-in for ActionDispatch::Http::ParameterFilter.
+# Replicates core behavior: matches hash keys against symbols and regexes,
+# replaces matched values with the mask.
+class SimpleParameterFilter
+  def initialize(fields, mask: '[FILTERED]')
+    @symbols = fields.select { |f| f.is_a?(Symbol) }.map(&:to_s)
+    @regexes = fields.select { |f| f.is_a?(Regexp) }
+    @mask = mask
+  end
+
+  def filter(hash)
+    hash.each_with_object({}) do |(key, value), result|
+      str_key = key.to_s
+      if match?(str_key)
+        result[key] = @mask
+      elsif value.is_a?(Hash)
+        result[key] = filter(value)
+      else
+        result[key] = value
+      end
+    end
+  end
+
+  private
+
+  def match?(key)
+    downkey = key.downcase
+    @symbols.any? { |s| downkey.include?(s.downcase) } ||
+      @regexes.any? { |r| key =~ r }
+  end
+end
+
+pii_filter = SimpleParameterFilter.new(Pii::DEFAULT_FIELDS)
+
+# ============================================================
+# Pii module constants
+# ============================================================
+puts "\n=== Pii::DEFAULT_FIELDS ==="
+assert_equal("is frozen", Pii::DEFAULT_FIELDS.frozen?)
+%i[email first_name last_name student_name username phone
+   phone_number address ssn date_of_birth password].each do |field|
+  assert_equal("includes :#{field}", Pii::DEFAULT_FIELDS.include?(field))
+end
+regexes = Pii::DEFAULT_FIELDS.select { |f| f.is_a?(Regexp) }
+assert_equal("includes /\\Aname\\z/i regex", regexes.include?(/\Aname\z/i))
+assert_equal("includes /\\Aip\\z/i regex", regexes.include?(/\Aip\z/i))
+
+puts "\n=== Pii::FILTERED ==="
+assert_equal("equals '[FILTERED]'", Pii::FILTERED == '[FILTERED]')
+
+puts "\n=== Pii::EMAIL_REGEX ==="
+assert_equal("matches student@example.com",
+      "student@example.com".match?(Pii::EMAIL_REGEX))
+assert_equal("matches jane.doe+tag@school.edu",
+      "jane.doe+tag@school.edu".match?(Pii::EMAIL_REGEX))
+assert_equal("does not match 'just a string'",
+      !"just a string".match?(Pii::EMAIL_REGEX))
+assert_equal("does not match 'user@'",
+      !"user@".match?(Pii::EMAIL_REGEX))
+
+puts "\n=== Pii::SSN_REGEX ==="
+assert_equal("matches 123-45-6789",
+      "123-45-6789".match?(Pii::SSN_REGEX))
+assert_equal("does not match 12345-6789",
+      !"12345-6789".match?(Pii::SSN_REGEX))
+assert_equal("does not match 123456789",
+      !"123456789".match?(Pii::SSN_REGEX))
+
+puts "\n=== Pii::PHONE_REGEX ==="
+assert_equal("matches (555) 123-4567",
+      "(555) 123-4567".match?(Pii::PHONE_REGEX))
+assert_equal("matches 555-123-4567",
+      "555-123-4567".match?(Pii::PHONE_REGEX))
+assert_equal("matches 555.123.4567",
+      "555.123.4567".match?(Pii::PHONE_REGEX))
+assert_equal("matches +1 555-123-4567",
+      "+1 555-123-4567".match?(Pii::PHONE_REGEX))
+assert_equal("matches plain 5551234567",
+      "5551234567".match?(Pii::PHONE_REGEX))
+assert_equal("does NOT match long numeric ID (1464597971234567890)",
+      !"1464597971234567890".match?(Pii::PHONE_REGEX))
+assert_equal("does NOT match Datadog trace IDs in JSON",
+      '{"trace_id":"5765288790315274587","span_id":"14645979712345678"}'
+        .scan(Pii::PHONE_REGEX).empty?)
+
+puts "\n=== Pii::PII_PATTERNS ==="
+assert_equal("is frozen", Pii::PII_PATTERNS.frozen?)
+assert_equal("includes EMAIL_REGEX", Pii::PII_PATTERNS.include?(Pii::EMAIL_REGEX))
+assert_equal("includes SSN_REGEX", Pii::PII_PATTERNS.include?(Pii::SSN_REGEX))
+assert_equal("includes PHONE_REGEX", Pii::PII_PATTERNS.include?(Pii::PHONE_REGEX))
+
+# ============================================================
+# ParameterFilter field scrubbing
+# ============================================================
+puts "\n=== ParameterFilter: field scrubbing ==="
+r = pii_filter.filter(email: "student@example.com", id: "abc-123")
+assert_equal("scrubs :email", r[:email] == '[FILTERED]')
+assert_equal("preserves :id", r[:id] == "abc-123")
+
+r = pii_filter.filter(name: "Jane Doe", role: "student")
+assert_equal("scrubs :name via regex anchor", r[:name] == '[FILTERED]')
+assert_equal("preserves :role", r[:role] == "student")
+
+r = pii_filter.filter(username: "jdoe", display_name: "Jane")
+assert_equal("scrubs :username", r[:username] == '[FILTERED]')
+assert_equal("preserves :display_name (not exact 'name')", r[:display_name] == "Jane")
+
+r = pii_filter.filter(first_name: "Victor", last_name: "Smith", grade: "A")
+assert_equal("scrubs :first_name", r[:first_name] == '[FILTERED]')
+assert_equal("scrubs :last_name", r[:last_name] == '[FILTERED]')
+assert_equal("preserves :grade", r[:grade] == "A")
+
+r = pii_filter.filter(student_name: "Violet Jones", course: "Math 101")
+assert_equal("scrubs :student_name", r[:student_name] == '[FILTERED]')
+assert_equal("preserves :course", r[:course] == "Math 101")
+
+r = pii_filter.filter(phone: "555-1234", address: "123 Main St",
+                       city: "Phoenix", zip: "85001")
+assert_equal("scrubs :phone", r[:phone] == '[FILTERED]')
+assert_equal("scrubs :address", r[:address] == '[FILTERED]')
+assert_equal("scrubs :city", r[:city] == '[FILTERED]')
+assert_equal("scrubs :zip", r[:zip] == '[FILTERED]')
+
+r = pii_filter.filter(ssn: "123-45-6789", date_of_birth: "2010-05-15",
+                       ip_address: "192.168.1.1")
+assert_equal("scrubs :ssn", r[:ssn] == '[FILTERED]')
+assert_equal("scrubs :date_of_birth", r[:date_of_birth] == '[FILTERED]')
+assert_equal("scrubs :ip_address", r[:ip_address] == '[FILTERED]')
+
+r = pii_filter.filter(password: "s3cret", token: "abc123",
+                       api_key: "key-456", authorization: "Bearer xyz")
+assert_equal("scrubs :password", r[:password] == '[FILTERED]')
+assert_equal("scrubs :token", r[:token] == '[FILTERED]')
+assert_equal("scrubs :api_key", r[:api_key] == '[FILTERED]')
+assert_equal("scrubs :authorization", r[:authorization] == '[FILTERED]')
+
+r = pii_filter.filter("email" => "student@example.com", "id" => "abc-123")
+assert_equal("scrubs string key 'email'", r["email"] == '[FILTERED]')
+assert_equal("preserves string key 'id'", r["id"] == "abc-123")
+
+puts "\n=== ParameterFilter: user hash scrubbing ==="
+user = { id: "user-42", email: "student@school.edu" }
+s = pii_filter.filter(user)
+s[:id] = user[:id]
+assert_equal("preserves symbol :id", s[:id] == "user-42")
+assert_equal("scrubs symbol :email", s[:email] == '[FILTERED]')
+
+user2 = { 'id' => "user-42", 'email' => "s@school.edu" }
+s2 = pii_filter.filter(user2)
+s2['id'] = user2['id']
+assert_equal("preserves string 'id'", s2['id'] == "user-42")
+assert_equal("scrubs string 'email'", s2['email'] == '[FILTERED]')
+
+puts "\n=== ParameterFilter: non-hash input ==="
+assert_equal("nil returns empty hash",
+      (nil.is_a?(Hash) ? pii_filter.filter(nil) : {}) == {})
+assert_equal("string returns empty hash",
+      ("not a hash".is_a?(Hash) ? pii_filter.filter("x") : {}) == {})
+
+# ============================================================
+# email regex in free text
+# ============================================================
+puts "\n=== Sentry: email regex in free text ==="
+msg = "User john.doe@school.edu failed to submit"
+assert_equal("scrubs email from message",
+      msg.gsub(Pii::EMAIL_REGEX, Pii::FILTERED) ==
+        "User [FILTERED] failed to submit")
+msg2 = "From a@b.com to c@d.org regarding enrollment"
+assert_equal("scrubs multiple emails",
+      msg2.gsub(Pii::EMAIL_REGEX, Pii::FILTERED) ==
+        "From [FILTERED] to [FILTERED] regarding enrollment")
+msg3 = "Assignment submitted at 3pm for course 101"
+assert_equal("preserves non-email text",
+      msg3.gsub(Pii::EMAIL_REGEX, Pii::FILTERED) == msg3)
+
+# ============================================================
+# string scrubbing
+# ============================================================
+puts "\n=== Formatter: string message scrubbing ==="
+assert_equal("scrubs email from string",
+      scrub_string("User student@example.com signed in") ==
+        "User [FILTERED] signed in")
+assert_equal("scrubs multiple emails",
+      !scrub_string("From a@b.com to c@d.org").include?("a@b.com"))
+assert_equal("scrubs SSN from string",
+      !scrub_string("SSN on file: 123-45-6789").include?("123-45-6789"))
+assert_equal("scrubs formatted phone",
+      !scrub_string("Contact at (555) 123-4567").include?("(555) 123-4567"))
+assert_equal("scrubs phone with country code",
+      !scrub_string("Call +1 555-123-4567").include?("+1 555-123-4567"))
+assert_equal("scrubs plain 10-digit phone",
+      !scrub_string("Phone: 5551234567").include?("5551234567"))
+assert_equal("preserves long numeric identifiers",
+      scrub_string("span_id: 1464597971234567890")
+        .include?("1464597971234567890"))
+assert_equal("preserves Datadog trace IDs in JSON",
+      scrub_string('{"trace_id":"5765288790315274587","span_id":"14645979712345678"}')
+        .include?("5765288790315274587"))
+assert_equal("preserves clean text",
+      scrub_string("Assignment submitted for course 101") ==
+        "Assignment submitted for course 101")
+
+# ============================================================
+# hash scrubbing via formatter
+# ============================================================
+puts "\n=== Formatter: hash message scrubbing ==="
+hash_scrubbed = pii_filter.filter(email: "student@example.com",
+                                   first_name: "Jane", org_id: 42)
+assert_equal("scrubs :email in hash", hash_scrubbed[:email] == '[FILTERED]')
+assert_equal("scrubs :first_name in hash", hash_scrubbed[:first_name] == '[FILTERED]')
+assert_equal("preserves :org_id in hash", hash_scrubbed[:org_id] == 42)
+
+clean_hash = pii_filter.filter(course: "Math 101", grade: "A")
+assert_equal("preserves non-PII :course", clean_hash[:course] == "Math 101")
+assert_equal("preserves non-PII :grade", clean_hash[:grade] == "A")
+
+# ============================================================
+# non-string/non-hash passthrough
+# ============================================================
+puts "\n=== Formatter: passthrough ==="
+assert_equal("integer passes through",
+      42.is_a?(String) == false && 42.is_a?(Hash) == false)
+assert_equal("nil passes through",
+      nil.is_a?(String) == false && nil.is_a?(Hash) == false)
+
+# ============================================================
+# formatter delegation
+# ============================================================
+puts "\n=== Formatter: Logger::Formatter integration ==="
+
+# Stub ActionDispatch::Http::ParameterFilter for vanilla Ruby.
+# Hash scrubbing was already verified above via SimpleParameterFilter;
+# this section tests the formatter's string path + delegation.
+unless defined?(ActionDispatch)
+  module ActionDispatch
+    module Http
+      class ParameterFilter
+        def initialize(_fields); end
+        def filter(hash); hash; end
+      end
+    end
+  end
+end
+
+require_relative '../lib/pii_logging_formatter'
+
+formatter = PiiLoggingFormatter.new(original_formatter: ::Logger::Formatter.new)
+ts = Time.now
+
+out = formatter.call("INFO", ts, "app", "User student@example.com signed in")
+assert_equal("formatter scrubs email",
+      !out.include?("student@example.com") && out.include?("[FILTERED]"))
+
+out2 = formatter.call("INFO", ts, "app", "SSN: 123-45-6789")
+assert_equal("formatter scrubs SSN", !out2.include?("123-45-6789"))
+
+out3 = formatter.call("INFO", ts, "app", "span_id: 1464597971234567890")
+assert_equal("formatter preserves long numeric IDs",
+      out3.include?("1464597971234567890"))
+
+out4 = formatter.call("INFO", ts, "app", "clean message")
+assert_equal("formatter includes message text", out4.include?("clean message"))
+assert_equal("formatter includes severity", out4.include?("INFO"))
+
+nil_fmt = PiiLoggingFormatter.new(original_formatter: nil)
+out5 = nil_fmt.call("INFO", ts, "app", "test")
+assert_equal("nil original_formatter defaults safely", out5.include?("test"))
+
+assert_equal("delegates respond_to? for :datetime_format",
+      formatter.respond_to?(:datetime_format))
+
+begin
+  formatter.nonexistent_method
+  assert_equal("raises NoMethodError for unknown methods", false)
+rescue NoMethodError
+  assert_equal("raises NoMethodError for unknown methods", true)
+end
+
+# ============================================================
+# Results
+# ============================================================
+puts "\n#{'=' * 50}"
+puts "Results: #{$results[:pass]} passed, #{$results[:fail]} failed"
+puts '=' * 50
+
+exit($results[:fail] > 0 ? 1 : 0)

--- a/spec/lib/pii_logging_formatter_spec.rb
+++ b/spec/lib/pii_logging_formatter_spec.rb
@@ -1,0 +1,145 @@
+#
+# Copyright (C) 2015 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+require_relative "../spec_helper"
+require "pii_logging_formatter"
+
+describe PiiLoggingFormatter do
+  let(:original_formatter) { ::Logger::Formatter.new }
+  let(:formatter) { described_class.new(original_formatter: original_formatter) }
+  let(:timestamp) { Time.now }
+  let(:filtered) { "[FILTERED]" }
+
+  describe "#call" do
+    context "with string messages containing email addresses" do
+      it "scrubs email addresses" do
+        result = formatter.call("INFO", timestamp, "app",
+                                "User student@example.com signed in")
+        expect(result).not_to include("student@example.com")
+        expect(result).to include(filtered)
+      end
+
+      it "scrubs multiple email addresses" do
+        result = formatter.call("INFO", timestamp, "app",
+                                "From a@b.com to c@d.org")
+        expect(result).not_to include("a@b.com")
+        expect(result).not_to include("c@d.org")
+      end
+    end
+
+    context "with string messages containing SSNs" do
+      it "scrubs SSN patterns" do
+        result = formatter.call("INFO", timestamp, "app",
+                                "SSN on file: 123-45-6789")
+        expect(result).not_to include("123-45-6789")
+        expect(result).to include(filtered)
+      end
+    end
+
+    context "with string messages containing phone numbers" do
+      it "scrubs formatted US phone numbers" do
+        result = formatter.call("INFO", timestamp, "app",
+                                "Contact at (555) 123-4567")
+        expect(result).not_to include("(555) 123-4567")
+        expect(result).to include(filtered)
+      end
+
+      it "scrubs phone numbers with country code" do
+        result = formatter.call("INFO", timestamp, "app",
+                                "Call +1 555-123-4567")
+        expect(result).not_to include("+1 555-123-4567")
+        expect(result).to include(filtered)
+      end
+
+      it "scrubs plain 10-digit phone numbers" do
+        result = formatter.call("INFO", timestamp, "app",
+                                "Phone: 5551234567")
+        expect(result).not_to include("5551234567")
+        expect(result).to include(filtered)
+      end
+
+      it "does not scrub long numeric identifiers" do
+        result = formatter.call("INFO", timestamp, "app",
+                                "span_id: 1464597971234567890")
+        expect(result).to include("1464597971234567890")
+        expect(result).not_to include(filtered)
+      end
+
+      it "does not scrub Datadog trace IDs in JSON" do
+        json_msg = '{"trace_id":"5765288790315274587","span_id":"14645979712345678"}'
+        result = formatter.call("INFO", timestamp, "app", json_msg)
+        expect(result).to include("5765288790315274587")
+        expect(result).to include("14645979712345678")
+        expect(result).not_to include(filtered)
+      end
+    end
+
+    context "with hash messages" do
+      it "scrubs PII key-value pairs" do
+        result = formatter.call("INFO", timestamp, "app",
+                                { email: "student@example.com",
+                                  first_name: "Jane", org_id: 42 })
+        expect(result).not_to include("student@example.com")
+        expect(result).not_to include("Jane")
+        expect(result).to include("42")
+      end
+
+      it "preserves non-PII keys" do
+        result = formatter.call("INFO", timestamp, "app",
+                                { course: "Math 101", grade: "A" })
+        expect(result).to include("Math 101")
+        expect(result).to include("A")
+      end
+    end
+
+    context "with non-string non-hash messages" do
+      it "passes through integer messages unchanged" do
+        result = formatter.call("INFO", timestamp, "app", 42)
+        expect(result).to include("42")
+      end
+
+      it "passes through nil messages" do
+        result = formatter.call("INFO", timestamp, "app", nil)
+        expect(result).to be_a(String)
+      end
+    end
+  end
+
+  describe "formatter delegation" do
+    it "delegates to original formatter for output" do
+      result = formatter.call("INFO", timestamp, "app", "clean message")
+      expect(result).to include("clean message")
+      expect(result).to include("INFO")
+    end
+
+    it "defaults to Logger::Formatter when nil is provided" do
+      nil_formatter = described_class.new(original_formatter: nil)
+      result = nil_formatter.call("INFO", timestamp, "app", "test")
+      expect(result).to include("test")
+    end
+  end
+
+  describe "method delegation" do
+    it "delegates unknown methods to original formatter" do
+      expect(formatter.respond_to?(:datetime_format)).to be true
+    end
+
+    it "raises NoMethodError for truly unknown methods" do
+      expect { formatter.nonexistent_method }.to raise_error(NoMethodError)
+    end
+  end
+end

--- a/spec/lib/pii_spec.rb
+++ b/spec/lib/pii_spec.rb
@@ -1,0 +1,104 @@
+#
+# Copyright (C) 2015 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+require_relative "../spec_helper"
+require "pii"
+
+describe Pii do
+  describe "DEFAULT_FIELDS" do
+    it "is frozen" do
+      expect(Pii::DEFAULT_FIELDS).to be_frozen
+    end
+
+    it "includes core PII field symbols" do
+      %i[email first_name last_name student_name username phone
+         phone_number address ssn date_of_birth password].each do |field|
+        expect(Pii::DEFAULT_FIELDS).to include(field)
+      end
+    end
+
+    it "includes regex anchors for name and ip" do
+      regexes = Pii::DEFAULT_FIELDS.select { |f| f.is_a?(Regexp) }
+      expect(regexes).to include(/\Aname\z/i)
+      expect(regexes).to include(/\Aip\z/i)
+    end
+  end
+
+  describe "FILTERED" do
+    it "equals [FILTERED]" do
+      expect(Pii::FILTERED).to eq("[FILTERED]")
+    end
+  end
+
+  describe "EMAIL_REGEX" do
+    it "matches standard email addresses" do
+      expect("student@example.com").to match(Pii::EMAIL_REGEX)
+      expect("jane.doe+tag@school.edu").to match(Pii::EMAIL_REGEX)
+    end
+
+    it "does not match non-email text" do
+      expect("just a string").not_to match(Pii::EMAIL_REGEX)
+      expect("user@").not_to match(Pii::EMAIL_REGEX)
+    end
+  end
+
+  describe "SSN_REGEX" do
+    it "matches SSN patterns" do
+      expect("123-45-6789").to match(Pii::SSN_REGEX)
+    end
+
+    it "does not match non-SSN numbers" do
+      expect("12345-6789").not_to match(Pii::SSN_REGEX)
+      expect("123456789").not_to match(Pii::SSN_REGEX)
+    end
+  end
+
+  describe "PHONE_REGEX" do
+    it "matches US phone numbers" do
+      expect("(555) 123-4567").to match(Pii::PHONE_REGEX)
+      expect("555-123-4567").to match(Pii::PHONE_REGEX)
+      expect("555.123.4567").to match(Pii::PHONE_REGEX)
+      expect("+1 555-123-4567").to match(Pii::PHONE_REGEX)
+    end
+
+    it "matches plain 10-digit phone numbers" do
+      expect("5551234567").to match(Pii::PHONE_REGEX)
+    end
+
+    it "does not match long numeric identifiers" do
+      expect("1464597971234567890").not_to match(Pii::PHONE_REGEX)
+    end
+
+    it "does not match Datadog trace IDs in JSON" do
+      json = '{"trace_id":"5765288790315274587","span_id":"14645979712345678"}'
+      matches = json.scan(Pii::PHONE_REGEX)
+      expect(matches).to be_empty
+    end
+  end
+
+  describe "PII_PATTERNS" do
+    it "is frozen" do
+      expect(Pii::PII_PATTERNS).to be_frozen
+    end
+
+    it "includes all three regex patterns" do
+      expect(Pii::PII_PATTERNS).to include(Pii::EMAIL_REGEX)
+      expect(Pii::PII_PATTERNS).to include(Pii::SSN_REGEX)
+      expect(Pii::PII_PATTERNS).to include(Pii::PHONE_REGEX)
+    end
+  end
+end

--- a/spec/lib/sentry_pii_scrubbing_spec.rb
+++ b/spec/lib/sentry_pii_scrubbing_spec.rb
@@ -16,32 +16,18 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 
 require_relative "../spec_helper"
+require "pii"
 
-# Inline PII scrubbing for Sentry events (for FERPA compliance purposes).
-# Mirrors PlatformSdk::Sentry::PiiScrubber but uses Rails 5-compatible
+# PII scrubbing for Sentry events (for FERPA compliance purposes).
+# Uses shared Pii module with Rails 5-compatible
 # ActionDispatch::Http::ParameterFilter as strongmind-platform-sdk
 # requires Rails >= 7.1.
 describe "Sentry PII Scrubbing" do
-  let(:pii_fields) do
-    [
-      :email, /\Aname\z/i, :first_name, :last_name, :student_name,
-      :username, :phone, :phone_number, :address, :street, :city,
-      :zip, :postal_code, :ssn, :social_security, :date_of_birth,
-      :dob, :birthday, :ip_address, /\Aip\z/i, :remote_ip,
-      :password, :password_confirmation, :token, :secret, :api_key,
-      :authorization
-    ]
-  end
-
   let(:pii_filter) do
-    ActionDispatch::Http::ParameterFilter.new(pii_fields)
+    ActionDispatch::Http::ParameterFilter.new(Pii::DEFAULT_FIELDS)
   end
 
-  let(:pii_email_regex) do
-    /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/
-  end
-
-  let(:filtered) { '[FILTERED]' }
+  let(:filtered) { Pii::FILTERED }
 
   describe "ParameterFilter field scrubbing" do
     it "scrubs email fields" do
@@ -145,13 +131,13 @@ describe "Sentry PII Scrubbing" do
   describe "email regex scrubbing in free text" do
     it "scrubs email addresses from messages" do
       message = "User john.doe@school.edu failed to submit"
-      scrubbed = message.gsub(pii_email_regex, filtered)
+      scrubbed = message.gsub(Pii::EMAIL_REGEX, filtered)
       expect(scrubbed).to eq("User #{filtered} failed to submit")
     end
 
     it "scrubs multiple email addresses" do
       message = "From a@b.com to c@d.org regarding enrollment"
-      scrubbed = message.gsub(pii_email_regex, filtered)
+      scrubbed = message.gsub(Pii::EMAIL_REGEX, filtered)
       expect(scrubbed).to eq(
         "From #{filtered} to #{filtered} regarding enrollment"
       )
@@ -159,7 +145,7 @@ describe "Sentry PII Scrubbing" do
 
     it "does not scrub non-email text" do
       message = "Assignment submitted at 3pm for course 101"
-      scrubbed = message.gsub(pii_email_regex, filtered)
+      scrubbed = message.gsub(Pii::EMAIL_REGEX, filtered)
       expect(scrubbed).to eq(message)
     end
   end


### PR DESCRIPTION
[NXT-8585](https://strongmind.atlassian.net/browse/NXT-8585)

## Purpose 
Add FERPA-compliant stdout log PII scrubbing to `canvas-lms` application.  Because `canvas-lms` runs on Rails 5 / Ruby 2.5, the `strongmind-platform-sdk` cannot be used (requires Rails >= 7.1 / Ruby >= 2.6).  PII scrubbing is therefore implemented inline using the same field list and logic as latest `PlatformSdk` version.

## Approach 
- Add `pii.rb` module into `lib/` subdir for shared constants
- Add new `pii_logging_formatter.rb` module into `lib/` subdir
- Add `pii_logging.rb` module into `/config/initializers/` subdir
- Update `/config/initializers/sentry.rb` to require new shared `Pii` module constants
- Update test setup in `sentry_pii_scrubbing_spec.rb` following related changes to initializer module
- Add new `pii_spec.rb` module into `/spec/lib/` subdir
- Add new `pii_logging_formatter_spec.rb` module into `/spec/lib/` subdir
- Add `verify_pii_scrubbing.rb` into `script/` subdir for additional testing purposes

## Testing
- Execute test script to verify new PII scrubbing modules are initialized, wired in correctly, and producing expected PII scrubbing behavior in alignment with SDK-based approach that is currently applied to all other (more modern) rails apps:
```shell
~/canvas-lms NXT-8585 $ ruby script/verify_pii_scrubbing.rb                                                                      

=== Pii::DEFAULT_FIELDS ===
  ✅ is frozen
  ✅ includes :email
  ✅ includes :first_name
  ✅ includes :last_name
  ✅ includes :student_name
  ✅ includes :username
  ✅ includes :phone
  ✅ includes :phone_number
  ✅ includes :address
  ✅ includes :ssn
  ✅ includes :date_of_birth
  ✅ includes :password
  ✅ includes /\Aname\z/i regex
  ✅ includes /\Aip\z/i regex

=== Pii::FILTERED ===
  ✅ equals '[FILTERED]'

=== Pii::EMAIL_REGEX ===
  ✅ matches student@example.com
  ✅ matches jane.doe+tag@school.edu
  ✅ does not match 'just a string'
  ✅ does not match 'user@'

=== Pii::SSN_REGEX ===
  ✅ matches 123-45-6789
  ✅ does not match 12345-6789
  ✅ does not match 123456789

=== Pii::PHONE_REGEX ===
  ✅ matches (555) 123-4567
  ✅ matches 555-123-4567
  ✅ matches 555.123.4567
  ✅ matches +1 555-123-4567
  ✅ matches plain 5551234567
  ✅ does NOT match long numeric ID (1464597971234567890)
  ✅ does NOT match Datadog trace IDs in JSON

=== Pii::PII_PATTERNS ===
  ✅ is frozen
  ✅ includes EMAIL_REGEX
  ✅ includes SSN_REGEX
  ✅ includes PHONE_REGEX

=== ParameterFilter: field scrubbing ===
  ✅ scrubs :email
  ✅ preserves :id
  ✅ scrubs :name via regex anchor
  ✅ preserves :role
  ✅ scrubs :username
  ✅ preserves :display_name (not exact 'name')
  ✅ scrubs :first_name
  ✅ scrubs :last_name
  ✅ preserves :grade
  ✅ scrubs :student_name
  ✅ preserves :course
  ✅ scrubs :phone
  ✅ scrubs :address
  ✅ scrubs :city
  ✅ scrubs :zip
  ✅ scrubs :ssn
  ✅ scrubs :date_of_birth
  ✅ scrubs :ip_address
  ✅ scrubs :password
  ✅ scrubs :token
  ✅ scrubs :api_key
  ✅ scrubs :authorization
  ✅ scrubs string key 'email'
  ✅ preserves string key 'id'

=== ParameterFilter: user hash scrubbing ===
  ✅ preserves symbol :id
  ✅ scrubs symbol :email
  ✅ preserves string 'id'
  ✅ scrubs string 'email'

=== ParameterFilter: non-hash input ===
  ✅ nil returns empty hash
  ✅ string returns empty hash

=== Sentry: email regex in free text ===
  ✅ scrubs email from message
  ✅ scrubs multiple emails
  ✅ preserves non-email text

=== Formatter: string message scrubbing ===
  ✅ scrubs email from string
  ✅ scrubs multiple emails
  ✅ scrubs SSN from string
  ✅ scrubs formatted phone
  ✅ scrubs phone with country code
  ✅ scrubs plain 10-digit phone
  ✅ preserves long numeric identifiers
  ✅ preserves Datadog trace IDs in JSON
  ✅ preserves clean text

=== Formatter: hash message scrubbing ===
  ✅ scrubs :email in hash
  ✅ scrubs :first_name in hash
  ✅ preserves :org_id in hash
  ✅ preserves non-PII :course
  ✅ preserves non-PII :grade

=== Formatter: passthrough ===
  ✅ integer passes through
  ✅ nil passes through

=== Formatter: Logger::Formatter integration ===
  ✅ formatter scrubs email
  ✅ formatter scrubs SSN
  ✅ formatter preserves long numeric IDs
  ✅ formatter includes message text
  ✅ formatter includes severity
  ✅ nil original_formatter defaults safely
  ✅ delegates respond_to? for :datetime_format
  ✅ raises NoMethodError for unknown methods

==================================================
Results: 90 passed, 0 failed
==================================================
```


[NXT-8585]: https://strongmind.atlassian.net/browse/NXT-8585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ