### PR TITLE
Fix QTY-19269: treat bare XML migration packages like imsmanifest.xml in archive.rb

### DIFF
--- a/lib/canvas/migration/archive.rb
+++ b/lib/canvas/migration/archive.rb
@@ -19,6 +19,9 @@ module Canvas::Migration
   class Archive
     attr_reader :warnings
 
+    IMSMANIFEST_XML = 'imsmanifest.xml'.freeze
+    XML_CARTRIDGE_MIME_TYPES = %w[application/xml text/xml].freeze
+
     def initialize(settings={})
       @settings = settings
       @warnings = []
@@ -93,6 +96,12 @@ module Canvas::Migration
     def unzip_archive
       return if @unzipped
       Rails.logger.debug "Extracting #{path} to #{unzipped_file_path}"
+      if bare_xml_cartridge?
+        copy_xml_cartridge_to!(IMSMANIFEST_XML)
+        @unzipped = true
+        return true
+      end
+
       warnings = CanvasUnzip.extract_archive(path, unzipped_file_path)
       @unzipped = true
       unless warnings.empty?
@@ -114,9 +123,10 @@ module Canvas::Migration
 
     # If the file is a zip file, unzip it, if it's an xml file, copy
     # it into the directory with the given file name
-    def prepare_cartridge_file(file_name='imsmanifest.xml')
+    def prepare_cartridge_file(file_name=IMSMANIFEST_XML)
       if self.path.ends_with?('xml')
-        FileUtils::cp(self.path, File.join(self.unzipped_file_path, file_name))
+        copy_xml_cartridge_to!(file_name)
+        @unzipped = true
       else
         unzip_archive
       end
@@ -130,6 +140,20 @@ module Canvas::Migration
 
     def add_warning(warning)
       @warnings << warning
+    end
+
+    private
+
+    def bare_xml_cartridge?
+      return true if path.to_s.end_with?('xml')
+
+      File.open(path, 'rb') do |f|
+        XML_CARTRIDGE_MIME_TYPES.include?(File.mime_type?(f))
+      end
+    end
+
+    def copy_xml_cartridge_to!(dest_name)
+      FileUtils.cp(path, File.join(unzipped_file_path, dest_name))
     end
   end
 end

--- a/lib/canvas/migration/archive.rb
+++ b/lib/canvas/migration/archive.rb
@@ -97,7 +97,7 @@ module Canvas::Migration
       return if @unzipped
       Rails.logger.debug "Extracting #{path} to #{unzipped_file_path}"
       if bare_xml_cartridge?
-        copy_xml_cartridge_to!(IMSMANIFEST_XML)
+        copy_xml_cartridge_to(IMSMANIFEST_XML)
         @unzipped = true
         return true
       end
@@ -125,7 +125,7 @@ module Canvas::Migration
     # it into the directory with the given file name
     def prepare_cartridge_file(file_name=IMSMANIFEST_XML)
       if self.path.ends_with?('xml')
-        copy_xml_cartridge_to!(file_name)
+        copy_xml_cartridge_to(file_name)
         @unzipped = true
       else
         unzip_archive
@@ -145,14 +145,14 @@ module Canvas::Migration
     private
 
     def bare_xml_cartridge?
-      return true if path.to_s.end_with?('xml')
+      return true if path.to_s.ends_with?('xml')
 
       File.open(path, 'rb') do |f|
         XML_CARTRIDGE_MIME_TYPES.include?(File.mime_type?(f))
       end
     end
 
-    def copy_xml_cartridge_to!(dest_name)
+    def copy_xml_cartridge_to(dest_name)
       FileUtils.cp(path, File.join(unzipped_file_path, dest_name))
     end
   end

--- a/spec/lib/canvas/migration_spec.rb
+++ b/spec/lib/canvas/migration_spec.rb
@@ -152,4 +152,27 @@ describe "Migration package importers" do
     end
   end
 
+  context "Canvas::Migration::Archive#unzip_archive" do
+    it "materializes application/xml packages without a .xml filename as imsmanifest.xml" do
+      tmp = Tempfile.new(['migration_pkg', ''])
+      tmp.write('<?xml version="1.0" encoding="UTF-8"?><manifest xmlns="http://www.imsglobal.org/xsd/imscp_v1p1"/>')
+      tmp.close
+      archive = Canvas::Migration::Archive.new(export_archive_path: tmp.path)
+      expect { archive.unzip_archive }.not_to raise_error
+      manifest = File.join(archive.unzipped_file_path, Canvas::Migration::Archive::IMSMANIFEST_XML)
+      expect(File).to be_exist(manifest)
+      expect(File.read(manifest)).to include('imscp_v1p1')
+      archive.delete_unzipped_archive
+      tmp.unlink
+    end
+
+    it "still extracts zip archives normally" do
+      zip_path = File.join(File.dirname(__FILE__), '../../fixtures/migration/whatthebackslash.zip')
+      archive = Canvas::Migration::Archive.new(export_archive_path: zip_path)
+      archive.unzip_archive
+      expect(File).to be_exist(File.join(archive.unzipped_file_path, 'messaging/why oh why.txt'))
+      archive.delete_unzipped_archive
+    end
+  end
+
 end


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/jira/software/c/projects/QTY/boards/575?selectedIssue=QTY-19269)

## Purpose
([Sentry CANVAS-LMS-2XP](https://strongmind-4j.sentry.io/issues/7428212950/?project=6262567&referrer=jira_integration)): QTI and other migration paths call Canvas::Migration::Archive#unzip_archive, which previously always delegated to CanvasUnzip. Files that sniff as application/xml / text/xml (e.g. temp paths without a .xml suffix) raised CanvasUnzip::UnknownArchiveType. We now copy those sources into imsmanifest.xml in the unzip temp dir—matching the existing Common Cartridge prepare_cartridge_file behavior—while leaving zip extraction unchanged.

## Testing
Added examples in spec/lib/canvas/migration_spec.rb under Canvas::Migration::Archive#unzip_archive.
1. a Tempfile with a non-.xml name containing minimal IMS CP manifest XML asserts imsmanifest.xml exists and no exception;
2. whatthebackslash.zip still extracts a known nested file.