### PR TITLE
QTY-19240: Gate delayed job staleness metric by env flag

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -147,49 +147,51 @@ Delayed::Worker.lifecycle.before(:error) do |worker, job, exception|
   end
 end
 
-JOB_STALENESS_METRIC_INTERVAL = 1.minute
-JOB_STALENESS_NEXT_PUBLISH_AT_KEY = :next_job_staleness_metric_publish_at
+module JobStalenessMetric
+  METRIC_INTERVAL = 1.minute
+  NEXT_PUBLISH_AT_KEY = :next_job_staleness_metric_publish_at
 
-def publish_job_staleness_metric
-  return unless ENV["JOB_STALENESS_METRIC_ENABLED"] == "true"
+  def self.publish
+    return unless ENV["JOB_STALENESS_METRIC_ENABLED"] == "true"
 
-  now = Time.now
-  next_publish_at = Thread.current[JOB_STALENESS_NEXT_PUBLISH_AT_KEY]
-  return if next_publish_at && now < next_publish_at
+    now = Time.now
+    next_publish_at = Thread.current[NEXT_PUBLISH_AT_KEY]
+    return if next_publish_at && now < next_publish_at
 
-  # This throttle is intentionally thread-local to avoid any Redis dependency in
-  # this loop callback. The metric is only enabled for iSucceed, where this
-  # per-thread publish frequency is acceptable.
-  Thread.current[JOB_STALENESS_NEXT_PUBLISH_AT_KEY] = now + JOB_STALENESS_METRIC_INTERVAL
+    # This throttle is intentionally thread-local to avoid any Redis dependency in
+    # this loop callback. The metric is only enabled for iSucceed, where this
+    # per-thread publish frequency is acceptable.
+    Thread.current[NEXT_PUBLISH_AT_KEY] = now + METRIC_INTERVAL
 
-  # Log the age in seconds of the oldest runnable job.
-  age = (DateTime.now.utc - (Delayed::Job.where(attempts: 0)
-                                         .where(locked_at: nil)
-                                         .where(next_in_strand: false)
-                                         .where('run_at <= ?', DateTime.now.utc)
-                                         .minimum(:run_at)&.to_datetime || DateTime.now.utc)).to_i
+    # Log the age in seconds of the oldest runnable job.
+    age = (DateTime.now.utc - (Delayed::Job.where(attempts: 0)
+                                           .where(locked_at: nil)
+                                           .where(next_in_strand: false)
+                                           .where('run_at <= ?', DateTime.now.utc)
+                                           .minimum(:run_at)&.to_datetime || DateTime.now.utc)).to_i
 
-  Aws::CloudWatch::Client.new(region: "us-west-2").put_metric_data(
-    namespace: "Canvas",
-    metric_data: [
-      {
-        metric_name: "JobStaleness",
-        dimensions: [
-          {
-            name: "domain",
-            value: ENV["CANVAS_DOMAIN"]
-          },
-        ],
-        timestamp: now,
-        value: age,
-        unit: "Seconds"
-      },
-    ]
-  )
-rescue => e
-  Rails.logger.warn("[JobStaleness] failed to publish: #{e.class}: #{e.message}")
+    Aws::CloudWatch::Client.new(region: "us-west-2").put_metric_data(
+      namespace: "Canvas",
+      metric_data: [
+        {
+          metric_name: "JobStaleness",
+          dimensions: [
+            {
+              name: "domain",
+              value: ENV["CANVAS_DOMAIN"]
+            },
+          ],
+          timestamp: now,
+          value: age,
+          unit: "Seconds"
+        },
+      ]
+    )
+  rescue => e
+    Rails.logger.warn("[JobStaleness] failed to publish: #{e.class}: #{e.message}")
+  end
 end
 
 Delayed::Worker.lifecycle.before(:loop) do |_worker|
-  publish_job_staleness_metric
+  JobStalenessMetric.publish
 end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -157,6 +157,9 @@ def publish_job_staleness_metric
   next_publish_at = Thread.current[JOB_STALENESS_NEXT_PUBLISH_AT_KEY]
   return if next_publish_at && now < next_publish_at
 
+  # This throttle is intentionally thread-local to avoid any Redis dependency in
+  # this loop callback. The metric is only enabled for iSucceed, where this
+  # per-thread publish frequency is acceptable.
   Thread.current[JOB_STALENESS_NEXT_PUBLISH_AT_KEY] = now + JOB_STALENESS_METRIC_INTERVAL
 
   # Log the age in seconds of the oldest runnable job.

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -147,34 +147,46 @@ Delayed::Worker.lifecycle.before(:error) do |worker, job, exception|
   end
 end
 
-Delayed::Worker.lifecycle.before(:loop) do |worker|
-  Rails.cache.fetch("loop_stats_has_run_within_1m", expires_in: 1.minute) do
+JOB_STALENESS_METRIC_INTERVAL = 1.minute
+JOB_STALENESS_NEXT_PUBLISH_AT_KEY = :next_job_staleness_metric_publish_at
 
-    # log the age in seconds of the oldest job
-    age = (DateTime.now.utc - (Delayed::Job.where(attempts: 0)
-                                           .where(locked_at: nil)
-                                           .where(next_in_strand: false)
-                        .where('run_at <= ?', DateTime.now.utc)
-                        .minimum(:run_at)&.to_datetime || DateTime.now.utc)).to_i
+def publish_job_staleness_metric
+  return unless ENV["JOB_STALENESS_METRIC_ENABLED"] == "true"
 
-    client = Aws::CloudWatch::Client.new(region: 'us-west-2')
-    client.put_metric_data({
-                             namespace: "Canvas",
-                             metric_data: [
-                               {
-                                 metric_name: "JobStaleness",
-                                 dimensions: [
-                                   {
-                                     name: "domain",
-                                     value: ENV['CANVAS_DOMAIN']
-                                   },
-                                 ],
-                                 timestamp: Time.now,
-                                 value: age,
-                                 unit: "Seconds"
-                               },
-                             ]
-                           })
-    true
-  end
+  now = Time.now
+  next_publish_at = Thread.current[JOB_STALENESS_NEXT_PUBLISH_AT_KEY]
+  return if next_publish_at && now < next_publish_at
+
+  Thread.current[JOB_STALENESS_NEXT_PUBLISH_AT_KEY] = now + JOB_STALENESS_METRIC_INTERVAL
+
+  # Log the age in seconds of the oldest runnable job.
+  age = (DateTime.now.utc - (Delayed::Job.where(attempts: 0)
+                                         .where(locked_at: nil)
+                                         .where(next_in_strand: false)
+                                         .where('run_at <= ?', DateTime.now.utc)
+                                         .minimum(:run_at)&.to_datetime || DateTime.now.utc)).to_i
+
+  Aws::CloudWatch::Client.new(region: "us-west-2").put_metric_data(
+    namespace: "Canvas",
+    metric_data: [
+      {
+        metric_name: "JobStaleness",
+        dimensions: [
+          {
+            name: "domain",
+            value: ENV["CANVAS_DOMAIN"]
+          },
+        ],
+        timestamp: now,
+        value: age,
+        unit: "Seconds"
+      },
+    ]
+  )
+rescue => e
+  Rails.logger.warn("[JobStaleness] failed to publish: #{e.class}: #{e.message}")
+end
+
+Delayed::Worker.lifecycle.before(:loop) do |_worker|
+  publish_job_staleness_metric
 end

--- a/spec/initializers/delayed_job_spec.rb
+++ b/spec/initializers/delayed_job_spec.rb
@@ -43,7 +43,7 @@ describe 'Delayed::Job' do
   end
 end
 
-describe "#publish_job_staleness_metric" do
+describe "JobStalenessMetric.publish" do
   let(:now) { Time.zone.parse("2026-05-01 10:00:00 UTC") }
   let(:cloudwatch_client) { instance_double(Aws::CloudWatch::Client) }
   let(:relation) { instance_double(ActiveRecord::Relation) }
@@ -57,7 +57,7 @@ describe "#publish_job_staleness_metric" do
   end
 
   before do
-    Thread.current[JOB_STALENESS_NEXT_PUBLISH_AT_KEY] = nil
+    Thread.current[JobStalenessMetric::NEXT_PUBLISH_AT_KEY] = nil
     allow(Aws::CloudWatch::Client).to receive(:new).with(region: "us-west-2").and_return(cloudwatch_client)
     allow(cloudwatch_client).to receive(:put_metric_data)
     allow(Rails.logger).to receive(:warn)
@@ -71,12 +71,12 @@ describe "#publish_job_staleness_metric" do
   end
 
   after do
-    Thread.current[JOB_STALENESS_NEXT_PUBLISH_AT_KEY] = nil
+    Thread.current[JobStalenessMetric::NEXT_PUBLISH_AT_KEY] = nil
   end
 
   it "skips when metric flag is unset" do
     with_job_staleness_metric_flag(nil) do
-      Object.new.send(:publish_job_staleness_metric)
+      JobStalenessMetric.publish
     end
 
     expect(cloudwatch_client).not_to have_received(:put_metric_data)
@@ -84,7 +84,7 @@ describe "#publish_job_staleness_metric" do
 
   it "skips when metric flag is not true" do
     with_job_staleness_metric_flag("false") do
-      Object.new.send(:publish_job_staleness_metric)
+      JobStalenessMetric.publish
     end
 
     expect(cloudwatch_client).not_to have_received(:put_metric_data)
@@ -92,7 +92,7 @@ describe "#publish_job_staleness_metric" do
 
   it "publishes once when enabled" do
     with_job_staleness_metric_flag("true") do
-      Object.new.send(:publish_job_staleness_metric)
+      JobStalenessMetric.publish
     end
 
     expect(cloudwatch_client).to have_received(:put_metric_data).once
@@ -100,8 +100,8 @@ describe "#publish_job_staleness_metric" do
 
   it "throttles repeated calls within one minute on the same thread" do
     with_job_staleness_metric_flag("true") do
-      Object.new.send(:publish_job_staleness_metric)
-      Object.new.send(:publish_job_staleness_metric)
+      JobStalenessMetric.publish
+      JobStalenessMetric.publish
     end
 
     expect(cloudwatch_client).to have_received(:put_metric_data).once
@@ -111,8 +111,8 @@ describe "#publish_job_staleness_metric" do
     allow(Time).to receive(:now).and_return(now, now + 61.seconds)
 
     with_job_staleness_metric_flag("true") do
-      Object.new.send(:publish_job_staleness_metric)
-      Object.new.send(:publish_job_staleness_metric)
+      JobStalenessMetric.publish
+      JobStalenessMetric.publish
     end
 
     expect(cloudwatch_client).to have_received(:put_metric_data).twice
@@ -122,7 +122,7 @@ describe "#publish_job_staleness_metric" do
     allow(cloudwatch_client).to receive(:put_metric_data).and_raise(StandardError.new("publish failure"))
 
     with_job_staleness_metric_flag("true") do
-      expect { Object.new.send(:publish_job_staleness_metric) }.not_to raise_error
+      expect { JobStalenessMetric.publish }.not_to raise_error
     end
 
     expect(Rails.logger).to have_received(:warn).with(/JobStaleness/)
@@ -132,7 +132,7 @@ describe "#publish_job_staleness_metric" do
     allow(Delayed::Job).to receive(:where).with(attempts: 0).and_raise(StandardError.new("db failure"))
 
     with_job_staleness_metric_flag("true") do
-      expect { Object.new.send(:publish_job_staleness_metric) }.not_to raise_error
+      expect { JobStalenessMetric.publish }.not_to raise_error
     end
 
     expect(Rails.logger).to have_received(:warn).with(/JobStaleness/)

--- a/spec/initializers/delayed_job_spec.rb
+++ b/spec/initializers/delayed_job_spec.rb
@@ -42,3 +42,100 @@ describe 'Delayed::Job' do
     end
   end
 end
+
+describe "#publish_job_staleness_metric" do
+  let(:now) { Time.zone.parse("2026-05-01 10:00:00 UTC") }
+  let(:cloudwatch_client) { instance_double(Aws::CloudWatch::Client) }
+  let(:relation) { instance_double(ActiveRecord::Relation) }
+
+  def with_job_staleness_metric_flag(value)
+    previous = ENV["JOB_STALENESS_METRIC_ENABLED"]
+    value.nil? ? ENV.delete("JOB_STALENESS_METRIC_ENABLED") : ENV["JOB_STALENESS_METRIC_ENABLED"] = value
+    yield
+  ensure
+    previous.nil? ? ENV.delete("JOB_STALENESS_METRIC_ENABLED") : ENV["JOB_STALENESS_METRIC_ENABLED"] = previous
+  end
+
+  before do
+    Thread.current[JOB_STALENESS_NEXT_PUBLISH_AT_KEY] = nil
+    allow(Aws::CloudWatch::Client).to receive(:new).with(region: "us-west-2").and_return(cloudwatch_client)
+    allow(cloudwatch_client).to receive(:put_metric_data)
+    allow(Rails.logger).to receive(:warn)
+
+    allow(Time).to receive(:now).and_return(now)
+    allow(Delayed::Job).to receive(:where).with(attempts: 0).and_return(relation)
+    allow(relation).to receive(:where).with(locked_at: nil).and_return(relation)
+    allow(relation).to receive(:where).with(next_in_strand: false).and_return(relation)
+    allow(relation).to receive(:where).with("run_at <= ?", instance_of(DateTime)).and_return(relation)
+    allow(relation).to receive(:minimum).with(:run_at).and_return(DateTime.now.utc - Rational(1, 24))
+  end
+
+  after do
+    Thread.current[JOB_STALENESS_NEXT_PUBLISH_AT_KEY] = nil
+  end
+
+  it "skips when metric flag is unset" do
+    with_job_staleness_metric_flag(nil) do
+      expect(Rails.cache).not_to receive(:fetch)
+      Object.new.send(:publish_job_staleness_metric)
+    end
+
+    expect(cloudwatch_client).not_to have_received(:put_metric_data)
+  end
+
+  it "skips when metric flag is not true" do
+    with_job_staleness_metric_flag("false") do
+      Object.new.send(:publish_job_staleness_metric)
+    end
+
+    expect(cloudwatch_client).not_to have_received(:put_metric_data)
+  end
+
+  it "publishes once when enabled" do
+    with_job_staleness_metric_flag("true") do
+      Object.new.send(:publish_job_staleness_metric)
+    end
+
+    expect(cloudwatch_client).to have_received(:put_metric_data).once
+  end
+
+  it "throttles repeated calls within one minute on the same thread" do
+    with_job_staleness_metric_flag("true") do
+      Object.new.send(:publish_job_staleness_metric)
+      Object.new.send(:publish_job_staleness_metric)
+    end
+
+    expect(cloudwatch_client).to have_received(:put_metric_data).once
+  end
+
+  it "publishes again after one minute has passed" do
+    allow(Time).to receive(:now).and_return(now, now + 61.seconds)
+
+    with_job_staleness_metric_flag("true") do
+      Object.new.send(:publish_job_staleness_metric)
+      Object.new.send(:publish_job_staleness_metric)
+    end
+
+    expect(cloudwatch_client).to have_received(:put_metric_data).twice
+  end
+
+  it "rescues and logs when cloudwatch publish raises" do
+    allow(cloudwatch_client).to receive(:put_metric_data).and_raise(StandardError.new("publish failure"))
+
+    with_job_staleness_metric_flag("true") do
+      expect { Object.new.send(:publish_job_staleness_metric) }.not_to raise_error
+    end
+
+    expect(Rails.logger).to have_received(:warn).with(/JobStaleness/)
+  end
+
+  it "rescues and logs when querying delayed jobs raises" do
+    allow(Delayed::Job).to receive(:where).with(attempts: 0).and_raise(StandardError.new("db failure"))
+
+    with_job_staleness_metric_flag("true") do
+      expect { Object.new.send(:publish_job_staleness_metric) }.not_to raise_error
+    end
+
+    expect(Rails.logger).to have_received(:warn).with(/JobStaleness/)
+  end
+end

--- a/spec/initializers/delayed_job_spec.rb
+++ b/spec/initializers/delayed_job_spec.rb
@@ -76,7 +76,6 @@ describe "#publish_job_staleness_metric" do
 
   it "skips when metric flag is unset" do
     with_job_staleness_metric_flag(nil) do
-      expect(Rails.cache).not_to receive(:fetch)
       Object.new.send(:publish_job_staleness_metric)
     end
 


### PR DESCRIPTION
[QTY-19240](https://strongmind.atlassian.net/browse/QTY-19240)

## Purpose
Silence Redis connection errors from legacy tenant workers by removing Redis from the delayed job staleness metric throttle path. Keep metric publishing available only where it still matters.

## Approach
- Replaced `Rails.cache.fetch` in the delayed-job loop callback with an opt-in env gate and thread-local one-minute throttle.
- Added rescue/logging around metric publishing so callback failures do not bubble as noisy Redis/Sentry failures.
- Added targeted specs for flag behavior, throttling, and error handling.

## Testing
- Attempted: `bundle exec rspec spec/initializers/delayed_job_spec.rb`
- Attempted: `bundle exec rubocop -A $(git diff --name-only main...HEAD -- '*.rb')`
- Both commands are blocked locally by Ruby runtime mismatch (`Gemfile` requires Ruby 2.5, local machine has 3.2.x installed).

## Screenshots/Video
N/A

Made with [Cursor](https://cursor.com)

[QTY-19240]: https://strongmind.atlassian.net/browse/QTY-19240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ