### PR TITLE
FSTN-4789: Add GrowthBook feature flag integration

### DIFF
--- a/Gemfile.d/app.rb
+++ b/Gemfile.d/app.rb
@@ -174,5 +174,6 @@ gem 'jquery-rails'
 gem 'rails-ujs'
 gem 'rb-readline'
 gem 'launchdarkly-server-sdk', '~> 6.0.0'
+gem 'growthbook'
 gem 'dotenv-rails', :groups => [:development, :test]
 gem "rack-timeout", require: "rack/timeout/base"

--- a/app/services/growthbook_service.rb
+++ b/app/services/growthbook_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class GrowthbookService
+  CACHE_KEY = 'growthbook_features'
+  CACHE_TTL = 1.minute
+
+  def self.enabled?(flag_key, attributes: nil)
+    return true if Rails.env.development?
+
+    attributes ||= {}
+    new.enabled?(flag_key, attributes:)
+  end
+
+  def enabled?(flag_key, attributes: {})
+    context = Growthbook::Context.new(
+      features: features_json,
+      attributes: attributes || {}
+    )
+    context.on?(flag_key)
+  end
+
+  private
+
+  def features_json
+    Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL) do
+      Growthbook::FeatureRepository.new(endpoint:, decryption_key: nil).fetch || {}
+    end
+  rescue StandardError => e
+    Rails.logger.warn("GrowthBook feature fetch failed: #{e.message}")
+    {}
+  end
+
+  def endpoint
+    @endpoint ||= ENV.fetch('GROWTHBOOK_ENDPOINT', nil)
+  end
+end

--- a/lib/tasks/strongmind.rake
+++ b/lib/tasks/strongmind.rake
@@ -268,6 +268,35 @@ namespace :strongmind do
     end
   end
 
+  GROWTHBOOK_PARITY_FLAGS = %w[
+    expose-ai-assistant
+    expose-discussion-entries-only-if-graded-submission-exists
+    expose-account-level-first-day-start-time
+    expose-course-level-passing-threshold-fields
+    expose-discussion-and-project-threshold-field
+  ].freeze
+
+  desc "Check GrowthBook feature flag parity across users. Pass USER_KEYS=key1,key2,..."
+  task :growthbook_parity => :environment do
+    abort("USER_KEYS is required. Example: USER_KEYS=isucceed-13425,primaverahs-122720") if ENV['USER_KEYS'].blank?
+
+    user_keys = ENV['USER_KEYS'].split(',').map(&:strip)
+    col_width = GROWTHBOOK_PARITY_FLAGS.map(&:length).max + 2
+
+    header = "%-#{col_width}s" % "FLAG" + user_keys.map { |k| "%-20s" % k }.join
+    puts header
+    puts "-" * header.length
+
+    GROWTHBOOK_PARITY_FLAGS.each do |flag|
+      row = "%-#{col_width}s" % flag
+      row += user_keys.map do |key|
+        result = GrowthbookService.enabled?(flag, attributes: { id: key })
+        "%-20s" % (result ? "true" : "false")
+      end.join
+      puts row
+    end
+  end
+
   desc "Set Identity Server 2.0 Auth Provider"
   task :set_id_server_auth, [:id] => :environment do |task, args|
     id = args[:id] ? args[:id].to_i : AccountAuthorizationConfig.last.id


### PR DESCRIPTION
## Summary
- Adds the `growthbook` gem alongside the existing LaunchDarkly SDK
- Introduces `GrowthbookService` modeled after Central's implementation, using `Growthbook::FeatureRepository` to fetch and cache feature definitions (1-minute TTL via `Rails.cache`)
- Adds `strongmind:growthbook_parity` rake task to check the state of all GrowthBook flags across a set of user keys for parity auditing

## Usage

**Feature flag check:**
```ruby
GrowthbookService.enabled?('expose-ai-assistant', attributes: { id: 'isucceed-13425' })
```

**Parity rake task:**
```
bundle exec rake strongmind:growthbook_parity USER_KEYS=isucceed-13425,primaverahs-122720
```

## Environment variable required
`GROWTHBOOK_ENDPOINT` — the GrowthBook features endpoint (e.g. `https://cdn.growthbook.io/api/features/<client_key>`)

## Test plan
- [ ] `GrowthbookService.enabled?` returns `true` in development without hitting the API
- [ ] `GrowthbookService.enabled?` returns `false` gracefully when `GROWTHBOOK_ENDPOINT` is not set
- [ ] Parity rake task prints a flag/user matrix when `USER_KEYS` is provided
- [ ] Parity rake task aborts with a helpful message when `USER_KEYS` is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)