### PR TITLE
Replace deleted nokogiri-xmlsec-me-harder with nokogiri-xmlsec-instructure

### DIFF
--- a/Gemfile.d/app.rb
+++ b/Gemfile.d/app.rb
@@ -101,7 +101,7 @@ gem 'net-ldap', '0.16.0', require: false
 gem 'ruby-duration', '3.2.3', require: false
 gem 'ruby-saml-mod', '0.3.6'
 gem 'saml2', '1.1.3', require: false
-  gem 'nokogiri-xmlsec-me-harder', '0.9.3pre', require: false, github: 'instructure/nokogiri-xmlsec-me-harder', ref: '57d071040cc4649db9f158e09bbcea028271a4a6'
+  gem 'nokogiri-xmlsec-instructure', '0.9.4', require: false
 gem 'rubycas-client', '2.3.9', require: false
 gem 'rubyzip', '1.2.0', require: 'zip'
 gem 'safe_yaml', '1.0.4', require: false


### PR DESCRIPTION
## Summary

- The `instructure/nokogiri-xmlsec-me-harder` GitHub repo was deleted, causing Docker builds to fail with a `git clone` authentication error whenever the Gemfile layer cache was busted
- Replaced the git-sourced gem with `nokogiri-xmlsec-instructure 0.9.4`, the official renamed successor published on RubyGems
- No code changes needed — the gem API is identical and there were no `require` calls for the old gem name in the codebase

## Test plan

- [ ] Docker build completes without `bundle install` errors
- [ ] SAML-related functionality still works (signing/signature verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1086" height="247" alt="image" src="https://github.com/user-attachments/assets/3f35407f-dfac-4c25-9be8-bd512202ca2f" />
