### PR TITLE
Fix Ruby 2.5 syntax error in growthbook_service.rb

### DIFF
--- a/app/services/growthbook_service.rb
+++ b/app/services/growthbook_service.rb
@@ -8,7 +8,7 @@ class GrowthbookService
     return true if Rails.env.development?
 
     attributes ||= {}
-    new.enabled?(flag_key, attributes:)
+    new.enabled?(flag_key, attributes: attributes)
   end
 
   def enabled?(flag_key, attributes: {})
@@ -23,7 +23,7 @@ class GrowthbookService
 
   def features_json
     Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL) do
-      Growthbook::FeatureRepository.new(endpoint:, decryption_key: nil).fetch || {}
+      Growthbook::FeatureRepository.new(endpoint: endpoint, decryption_key: nil).fetch || {}
     end
   rescue StandardError => e
     Rails.logger.warn("GrowthBook feature fetch failed: #{e.message}")


### PR DESCRIPTION
## Summary

`growthbook_service.rb` was using Ruby 3.1+ shorthand keyword argument syntax that is not valid in Ruby 2.5, causing the app to crash on boot in production.

**Errors:**
```
growthbook_service.rb:11: syntax error, unexpected ')' ...enabled?(flag_key, attributes:)
growthbook_service.rb:26: syntax error, unexpected ',' ...FeatureRepository.new(endpoint:, decryption_key: nil)
```

**Fix:** Expand shorthand to explicit form compatible with Ruby 2.5:
- `attributes:` → `attributes: attributes`
- `endpoint:` → `endpoint: endpoint`

## Test plan

- [ ] App boots successfully in production
- [ ] GrowthBook feature flags resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)