### PR TITLE
chore(FSTN-4834): remove unused LaunchDarkly SDK

### DIFF
--- a/Gemfile.d/app.rb
+++ b/Gemfile.d/app.rb
@@ -173,7 +173,6 @@ gem 'bootsnap', require: false
 gem 'jquery-rails'
 gem 'rails-ujs'
 gem 'rb-readline'
-gem 'launchdarkly-server-sdk', '~> 6.0.0'
 gem 'growthbook'
 gem 'dotenv-rails', '2.2.1', :groups => [:development, :test]
 gem "rack-timeout", require: "rack/timeout/base"

--- a/config/initializers/launch_darkly.rb
+++ b/config/initializers/launch_darkly.rb
@@ -1,7 +1,0 @@
-opts = {}
-opts[:capacity] = 15000
-opts[:flush_interval] = 60
-opts[:diagnostic_opt_out] = true
-config = LaunchDarkly::Config.new(opts)
-
-Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new(ENV['LAUNCH_DARKLY_SDK_KEY'], config)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -49,15 +49,6 @@ plugin :tmp_restart
 # write out a pid file
 pidfile './tmp/puma.pid'
 
-on_worker_boot do
-  opts = {}
-  opts[:capacity] = 15000
-  opts[:flush_interval] = 60
-  opts[:diagnostic_opt_out] = true
-  config = LaunchDarkly::Config.new(opts)
-  Rails.configuration.launch_darkly_client = LaunchDarkly::LDClient.new(ENV['LAUNCH_DARKLY_SDK_KEY'], config)
-end
-
 if ENV['RACK_ENV'] == 'development'
   worker_timeout 3600
 end


### PR DESCRIPTION
[FSTN-4834](https://strongmind.atlassian.net/browse/FSTN-4834)

## Purpose
Remove the now-unused LaunchDarkly SDK from canvas-lms (ADR-0011). All feature flags were **already migrated to GrowthBook** (`GrowthbookService`, in canvas-lms + the `canvas_shim` submodule) — nothing reads the LaunchDarkly client anymore, so only dead SDK code remains.

## Approach
- Remove the `launchdarkly-server-sdk` gem from `Gemfile.d/app.rb`.
- Delete `config/initializers/launch_darkly.rb` (LD client init).
- Remove the `on_worker_boot` LD client block in `config/puma.rb`.

## Testing
- Grep confirms no remaining `launchdarkly` / `launch_darkly_client` references or readers in the repo; `growthbook` gem retained; `ruby -c` clean on the edited files. No behavior change (flags already served by GrowthBook).

## Notes
- Minimal diff to limit upstream-merge friction on the fork. Ops: confirm `GROWTHBOOK_ENDPOINT` is set per env (already required by the existing GrowthbookService) and retire the `LAUNCH_DARKLY_SDK_KEY` env injection after merge.

[FSTN-4834]: https://strongmind.atlassian.net/browse/FSTN-4834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ